### PR TITLE
Initial implementation of Graph model and a basic data adapter

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,19 +47,19 @@ gulp.task("uglify-index", function () {
         .pipe(dest());
 });
 
-gulp.task("uglify-libs", function () {
+gulp.task("uglify-cliquefix", function () {
     "use strict";
 
     var dest = _.bind(gulp.dest, gulp, "build/site");
 
     return gulp.src([
-        "src/js/preamble.js",
+        "src/js/lib/preamble.js",
         "src/js/lib/**/*.js"
     ])
-        .pipe(concat("libs.js"))
+        .pipe(concat("cliquefix.js"))
         .pipe(dest())
         .pipe(uglify())
-        .pipe(rename("libs.min.js"))
+        .pipe(rename("cliquefix.min.js"))
         .pipe(dest());
 });
 
@@ -95,7 +95,7 @@ gulp.task("clean", function () {
 
 gulp.task("uglify", [
     "uglify-index",
-    "uglify-libs"
+    "uglify-cliquefix"
 ]);
 
 gulp.task("default", [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,6 +53,7 @@ gulp.task("uglify-cliquefix", function () {
     var dest = _.bind(gulp.dest, gulp, "build/site");
 
     return gulp.src([
+        "node_modules/jshashes/hashes.js",
         "src/js/lib/preamble.js",
         "src/js/lib/error.js",
         "src/js/lib/**/*.js"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,6 +54,7 @@ gulp.task("uglify-cliquefix", function () {
 
     return gulp.src([
         "src/js/lib/preamble.js",
+        "src/js/lib/error.js",
         "src/js/lib/**/*.js"
     ])
         .pipe(concat("cliquefix.js"))

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp-rimraf": "^0.1.1",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.4",
+    "jshashes": "^1.0.5",
     "jshint-stylish": "^1.0.1",
     "underscore": "^1.8.3"
   }

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -3,6 +3,10 @@ head
     title Placeholder page
 
     script(src="https://code.jquery.com/jquery-1.11.2.min.js")
+    script(src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js")
+    script(src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.2/backbone-min.js")
+
+    script(src="cliquefix.min.js")
     script(src="index.min.js")
 
 body

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,8 +1,39 @@
 /*jshint browser: true, jquery: true */
+/*global cf */
 
 $(function () {
     "use strict";
 
+    var graph;
+
     $("#content").html("<p>Hello</p>");
-    console.log("hello");
+
+    window.graph = graph = new cf.Graph({
+        adapter: cf.adapter.NodeEdgeList,
+        options: {
+            nodes: [
+                {name: "a"},
+                {name: "b"},
+                {name: "c"},
+                {name: "d"},
+                {name: "e"}
+            ],
+            edges: [
+                {source: 0, target: 2},
+                {source: 0, target: 4},
+                {source: 0, target: 5},
+                {source: 1, target: 4},
+                {source: 2, target: 3},
+                {source: 2, target: 4},
+                {source: 3, target: 0},
+                {source: 3, target: 5},
+                {source: 5, target: 4}
+            ]
+        }
+    });
+
+    window.results = graph.getNeighborhood({
+        name: "b",
+        radius: 2
+    });
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -9,7 +9,7 @@ $(function () {
     $("#content").html("<p>Hello</p>");
 
     window.graph = graph = new cf.Graph({
-        adapter: cf.adapter.NodeEdgeList,
+        adapter: cf.adapter.NodeLinkList,
         options: {
             nodes: [
                 {name: "a"},

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -33,10 +33,21 @@ $(function () {
         }
     });
 
-    window.results = graph.getNeighborhood({
+    graph.getNeighborhood({
         center: {
             name: "b"
         },
         radius: 1
     });
+
+    console.log(JSON.stringify(graph.attributes, null, 4));
+
+    graph.getNeighborhood({
+        center: {
+            name: "c"
+        },
+        radius: 1
+    });
+
+    console.log(JSON.stringify(graph.attributes, null, 4));
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -34,6 +34,6 @@ $(function () {
 
     window.results = graph.getNeighborhood({
         name: "b",
-        radius: 2
+        radius: 1
     });
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -16,7 +16,8 @@ $(function () {
                 {name: "b"},
                 {name: "c"},
                 {name: "d"},
-                {name: "e"}
+                {name: "e"},
+                {name: "f"}
             ],
             edges: [
                 {source: 0, target: 2},
@@ -33,7 +34,9 @@ $(function () {
     });
 
     window.results = graph.getNeighborhood({
-        name: "b",
+        center: {
+            name: "b"
+        },
         radius: 1
     });
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -19,7 +19,7 @@ $(function () {
                 {name: "e"},
                 {name: "f"}
             ],
-            edges: [
+            links: [
                 {source: 0, target: 2},
                 {source: 0, target: 4},
                 {source: 0, target: 5},

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -5,7 +5,7 @@
 
     cf.adapter.NodeEdgeList = function (cfg) {
         var nodes = cfg.nodes,
-            edges = cfg.edges,
+            links = cfg.links,
             nodeIndex = {},
             sourceIndex = {},
             targetIndex = {};
@@ -14,8 +14,8 @@
             throw cf.error.required("nodes");
         }
 
-        if (!edges) {
-            throw cf.error.required("edges");
+        if (!links) {
+            throw cf.error.required("links");
         }
 
         _.each(nodes, function (n) {
@@ -24,7 +24,7 @@
             nodeIndex[hash] = n;
         });
 
-        _.each(edges, function (e) {
+        _.each(links, function (e) {
             var sourceNode = nodes[e.source],
                 targetNode = nodes[e.target];
 
@@ -63,7 +63,7 @@
                     _.each(_.range(options.radius), function () {
                         var newFrontier = new cf.util.Set();
 
-                        // Find all edges to and from the current frontier
+                        // Find all links to and from the current frontier
                         // nodes.
                         _.each(frontier.items(), function (nodeKey) {
                             _.each(sourceIndex[nodeKey], function (neighborKey) {
@@ -75,20 +75,20 @@
                             });
                         });
 
-                        // Collect the nodes named in the edges.
-                        _.each(neighborEdges.items(), function (edge) {
-                            edge = JSON.parse(edge);
+                        // Collect the nodes named in the links.
+                        _.each(neighborEdges.items(), function (link) {
+                            link = JSON.parse(link);
 
-                            if (!neighborNodes.has(edge[0])) {
-                                newFrontier.add(edge[0]);
+                            if (!neighborNodes.has(link[0])) {
+                                newFrontier.add(link[0]);
                             }
 
-                            if (!neighborNodes.has(edge[1])) {
-                                newFrontier.add(edge[1]);
+                            if (!neighborNodes.has(link[1])) {
+                                newFrontier.add(link[1]);
                             }
 
-                            neighborNodes.add(edge[0]);
-                            neighborNodes.add(edge[1]);
+                            neighborNodes.add(link[0]);
+                            neighborNodes.add(link[1]);
                         });
 
                         frontier = newFrontier;
@@ -97,12 +97,12 @@
 
                 return {
                     nodes: _.map(neighborNodes.items(), _.propertyOf(nodeIndex)),
-                    edges: _.map(neighborEdges.items(), function (edge) {
-                        edge = JSON.parse(edge);
+                    links: _.map(neighborEdges.items(), function (link) {
+                        link = JSON.parse(link);
 
                         return {
-                            source: nodeIndex[edge[0]],
-                            target: nodeIndex[edge[1]]
+                            source: nodeIndex[link[0]],
+                            target: nodeIndex[link[1]]
                         };
                     })
                 };

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -1,0 +1,120 @@
+(function (cf, _) {
+    "use strict";
+
+    cf.adapter = {};
+
+    cf.adapter.NodeEdgeList = function (cfg) {
+        var nodes = cfg.nodes,
+            edges = cfg.edges,
+            nodeIndex = {},
+            edgeIndex = {}, sourceIndex = {},
+            targetIndex = {};
+
+        if (!nodes) {
+            throw cf.error.required("nodes");
+        }
+
+        if (!edges) {
+            throw cf.error.required("edges");
+        }
+
+        _.each(nodes, function (n, i) {
+            if (_.has(nodeIndex, n.name)) {
+                throw new Error("duplicate name '" + n.name + "' in node list");
+            }
+
+            nodeIndex[n.name] = n;
+            n.index = i;
+        });
+
+        _.each(edges, function (e) {
+            edgeIndex[[e.source, e.target]] = e;
+
+            sourceIndex[e.source] = sourceIndex[e.source] || {};
+            sourceIndex[e.source][e.target] = e;
+
+            targetIndex[e.target] = targetIndex[e.target] || {};
+            targetIndex[e.target][e.source] = e;
+        });
+
+        return {
+            getNeighborhood: function (options) {
+                var center,
+                    frontier = {},
+                    neighborNodes = {},
+                    neighborEdges = {};
+
+                if (!options.name) {
+                    throw cf.error.required("name");
+                }
+
+                if (!options.radius) {
+                    throw cf.error.required("radius");
+                }
+
+                center = nodeIndex[options.name];
+
+                if (center) {
+                    neighborNodes[center.index] = true;
+                    frontier[center.index] = true;
+
+                    // Fan out from the center to reach the requested radius.
+                    _.each(_.range(options.radius), function () {
+                        var newFrontier = {};
+
+                        // Find all edges to and from the current frontier
+                        // nodes.
+                        _.each(frontier, function (node) {
+                            _.each(sourceIndex[node.index], function (neighbor) {
+                                neighborEdges[[node.index, neighbor]] = true;
+                            });
+
+                            _.each(targetIndex[node.index], function (neighbor) {
+                                neighborEdges[[neighbor, node.index]] = true;
+                            });
+                        });
+
+                        // Collect the nodes named in the edges.
+                        _.each(neighborEdges, function (dummy, edge) {
+                            if (!_.has(neighborNodes, edge[0])) {
+                                newFrontier[edge[0]] = true;
+                            }
+
+                            if (!_.has(neighborNodes, edge[1])) {
+                                newFrontier[edge[1]] = true;
+                            }
+
+                            neighborNodes[edge[0]] = true;
+                            neighborNodes[edge[1]] = true;
+                        });
+
+                        frontier = newFrontier;
+                    });
+                }
+
+                neighborNodes = _.keys(neighborNodes).sort(function (a, b) {
+                    return a - b;
+                });
+
+                neighborEdges = _.keys(neighborEdges).sort(function (a, b) {
+                    return a[0] - b[0] === 0 ? a[1] - b[1] : a[0] - b[0];
+                });
+
+                console.log(neighborNodes);
+                console.log(neighborEdges);
+
+                return {
+                    nodes: _.map(neighborNodes, function (i) {
+                        return nodes[i];
+                    }),
+                    edges: _.map(neighborEdges, function (edge) {
+                        return {
+                            source: edge[0],
+                            target: edge[1]
+                        };
+                    })
+                };
+            }
+        };
+    };
+}(window.cf, window._));

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -24,21 +24,16 @@
             nodeIndex[hash] = n;
         });
 
-        console.log("nodeIndex", nodeIndex);
-
         _.each(edges, function (e) {
             var sourceNode = nodes[e.source],
                 targetNode = nodes[e.target];
 
             sourceIndex[sourceNode.key] = sourceIndex[sourceNode.key] || {};
-            sourceIndex[sourceNode.key][targetNode.key] = targetNode.key
+            sourceIndex[sourceNode.key][targetNode.key] = targetNode.key;
 
             targetIndex[targetNode.key] = targetIndex[targetNode.key] || {};
             targetIndex[targetNode.key][sourceNode.key] = sourceNode.key;
         });
-
-        console.log("sourceIndex", sourceIndex);
-        console.log("targetIndex", targetIndex);
 
         return {
             getNeighborhood: function (options) {
@@ -65,14 +60,11 @@
                     frontier.add(center.key);
 
                     // Fan out from the center to reach the requested radius.
-                    _.each(_.range(options.radius), function (i) {
-                        console.log("hop", i);
-
+                    _.each(_.range(options.radius), function () {
                         var newFrontier = new cf.util.Set();
 
                         // Find all edges to and from the current frontier
                         // nodes.
-                        console.log("frontier", frontier);
                         _.each(frontier.items(), function (nodeKey) {
                             _.each(sourceIndex[nodeKey], function (neighborKey) {
                                 neighborEdges.add(JSON.stringify([nodeKey, neighborKey]));
@@ -83,13 +75,9 @@
                             });
                         });
 
-                        console.log("neighborEdges", neighborEdges.items());
-
                         // Collect the nodes named in the edges.
                         _.each(neighborEdges.items(), function (edge) {
                             edge = JSON.parse(edge);
-
-                            console.log("edge", edge);
 
                             if (!neighborNodes.has(edge[0])) {
                                 newFrontier.add(edge[0]);
@@ -103,30 +91,13 @@
                             neighborNodes.add(edge[1]);
                         });
 
-                        console.log("newFrontier", newFrontier.items());
-
                         frontier = newFrontier;
                     });
                 }
 
-                neighborNodes = neighborNodes.items();
-/*                neighborNodes = _.keys(neighborNodes).sort(function (a, b) {*/
-                    // return a - b;
-                // });
-
-                neighborEdges = neighborEdges.items();
-/*                neighborEdges = _.keys(neighborEdges).sort(function (a, b) {*/
-                    // return a[0] - b[0] === 0 ? a[1] - b[1] : a[0] - b[0];
-                // });
-
-                console.log(neighborNodes);
-                console.log(neighborEdges);
-
                 return {
-                    nodes: _.map(neighborNodes, function (i) {
-                        return nodeIndex[i];
-                    }),
-                    edges: _.map(neighborEdges, function (edge) {
+                    nodes: _.map(neighborNodes.items(), _.propertyOf(nodeIndex)),
+                    edges: _.map(neighborEdges.items(), function (edge) {
                         edge = JSON.parse(edge);
 
                         return {

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -3,7 +3,7 @@
 
     cf.adapter = {};
 
-    cf.adapter.NodeEdgeList = function (cfg) {
+    cf.adapter.NodeLinkList = function (cfg) {
         var nodes = cfg.nodes,
             links = cfg.links,
             nodeIndex = {},
@@ -40,7 +40,7 @@
                 var center,
                     frontier,
                     neighborNodes = new cf.util.Set(),
-                    neighborEdges = new cf.util.Set();
+                    neighborLinks = new cf.util.Set();
 
                 if (!options.center) {
                     throw cf.error.required("name");
@@ -67,16 +67,16 @@
                         // nodes.
                         _.each(frontier.items(), function (nodeKey) {
                             _.each(sourceIndex[nodeKey], function (neighborKey) {
-                                neighborEdges.add(JSON.stringify([nodeKey, neighborKey]));
+                                neighborLinks.add(JSON.stringify([nodeKey, neighborKey]));
                             });
 
                             _.each(targetIndex[nodeKey], function (neighborKey) {
-                                neighborEdges.add(JSON.stringify([neighborKey, nodeKey]));
+                                neighborLinks.add(JSON.stringify([neighborKey, nodeKey]));
                             });
                         });
 
                         // Collect the nodes named in the links.
-                        _.each(neighborEdges.items(), function (link) {
+                        _.each(neighborLinks.items(), function (link) {
                             link = JSON.parse(link);
 
                             if (!neighborNodes.has(link[0])) {
@@ -97,7 +97,7 @@
 
                 return {
                     nodes: _.map(neighborNodes.items(), _.propertyOf(nodeIndex)),
-                    links: _.map(neighborEdges.items(), function (link) {
+                    links: _.map(neighborLinks.items(), function (link) {
                         link = JSON.parse(link);
 
                         return {

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -7,7 +7,8 @@
         var nodes = cfg.nodes,
             edges = cfg.edges,
             nodeIndex = {},
-            edgeIndex = {}, sourceIndex = {},
+            edgeIndex = {},
+            sourceIndex = {},
             targetIndex = {};
 
         if (!nodes) {
@@ -31,11 +32,14 @@
             edgeIndex[[e.source, e.target]] = e;
 
             sourceIndex[e.source] = sourceIndex[e.source] || {};
-            sourceIndex[e.source][e.target] = e;
+            sourceIndex[e.source][e.target] = true;
 
             targetIndex[e.target] = targetIndex[e.target] || {};
-            targetIndex[e.target][e.source] = e;
+            targetIndex[e.target][e.source] = true;
         });
+
+        console.log("sourceIndex", sourceIndex);
+        console.log("targetIndex", targetIndex);
 
         return {
             getNeighborhood: function (options) {
@@ -59,23 +63,41 @@
                     frontier[center.index] = true;
 
                     // Fan out from the center to reach the requested radius.
-                    _.each(_.range(options.radius), function () {
+                    _.each(_.range(options.radius), function (i) {
+                        console.log("hop", i);
+
                         var newFrontier = {};
 
                         // Find all edges to and from the current frontier
                         // nodes.
-                        _.each(frontier, function (node) {
-                            _.each(sourceIndex[node.index], function (neighbor) {
-                                neighborEdges[[node.index, neighbor]] = true;
+                        console.log("frontier", frontier);
+                        _.each(frontier, function (dummy, i) {
+                            var node = nodes[i];
+
+                            console.log("foo", i);
+                            console.log("foo", node);
+                            console.log("foo", node.index);
+                            console.log("foo", sourceIndex[node.index]);
+
+                            _.each(sourceIndex[node.index], function (dummy, neighbor) {
+                                neighbor = Number(neighbor);
+                                neighborEdges[JSON.stringify([node.index, neighbor])] = true;
                             });
 
-                            _.each(targetIndex[node.index], function (neighbor) {
-                                neighborEdges[[neighbor, node.index]] = true;
+                            _.each(targetIndex[node.index], function (dummy, neighbor) {
+                                neighbor = Number(neighbor);
+                                neighborEdges[JSON.stringify([neighbor, node.index])] = true;
                             });
                         });
 
+                        console.log("neighborEdges", neighborEdges);
+
                         // Collect the nodes named in the edges.
                         _.each(neighborEdges, function (dummy, edge) {
+                            edge = JSON.parse(edge);
+
+                            console.log("edge", edge);
+
                             if (!_.has(neighborNodes, edge[0])) {
                                 newFrontier[edge[0]] = true;
                             }
@@ -87,6 +109,8 @@
                             neighborNodes[edge[0]] = true;
                             neighborNodes[edge[1]] = true;
                         });
+
+                        console.log("newFrontier", newFrontier);
 
                         frontier = newFrontier;
                     });
@@ -108,6 +132,8 @@
                         return nodes[i];
                     }),
                     edges: _.map(neighborEdges, function (edge) {
+                        edge = JSON.parse(edge);
+
                         return {
                             source: edge[0],
                             target: edge[1]

--- a/src/js/lib/error.js
+++ b/src/js/lib/error.js
@@ -1,0 +1,9 @@
+(function (cf) {
+    "use strict";
+
+    cf.error = {};
+
+    cf.error.required = function (what) {
+        return new Error("option '" + what + "' is required");
+    };
+}(window.cf));

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -3,7 +3,15 @@
 
     cf.Graph = Backbone.Model.extend({
         initialize: function (options) {
-            console.log(options);
+            if (!options.adapter) {
+                throw cf.error.required("adapter");
+            }
+
+            this.adapter = new options.adapter(options.options);
+        },
+
+        getNeighborhood: function (options) {
+            return this.adapter.getNeighborhood(options);
         }
     });
 }(window.cf, window.Backbone));

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -1,0 +1,9 @@
+(function (cf, Backbone) {
+    "use strict";
+
+    cf.Graph = Backbone.Model.extend({
+        initialize: function (options) {
+            console.log(options);
+        }
+    });
+}(window.cf, window.Backbone));

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -32,11 +32,11 @@
                 }
             }, this));
 
-            _.each(nbd.edges, _.bind(function (edge) {
-                var edgeKey = JSON.stringify([edge.source.key, edge.target.key]);
-                if (!this.links.has(edgeKey)) {
-                    this.links.add(edgeKey);
-                    newLinks.push(edge);
+            _.each(nbd.links, _.bind(function (link) {
+                var linkKey = JSON.stringify([link.source.key, link.target.key]);
+                if (!this.links.has(linkKey)) {
+                    this.links.add(linkKey);
+                    newLinks.push(link);
                 }
             }, this));
 

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -1,17 +1,47 @@
-(function (cf, Backbone) {
+(function (cf, Backbone, _) {
     "use strict";
 
     cf.Graph = Backbone.Model.extend({
-        initialize: function (options) {
+        constructor: function (options) {
+            Backbone.Model.call(this, {}, options || {});
+        },
+
+        initialize: function (attributes, options) {
             if (!options.adapter) {
                 throw cf.error.required("adapter");
             }
 
             this.adapter = new options.adapter(options.options);
+
+            this.nodes = new cf.util.Set();
+            this.links = new cf.util.Set();
+
+            this.set("nodes", []);
+            this.set("links", []);
         },
 
         getNeighborhood: function (options) {
-            return this.adapter.getNeighborhood(options);
+            var nbd = this.adapter.getNeighborhood(options),
+                newNodes = [],
+                newLinks = [];
+
+            _.each(nbd.nodes, _.bind(function (node) {
+                if (!this.nodes.has(node.key)) {
+                    this.nodes.add(node.key);
+                    newNodes.push(node);
+                }
+            }, this));
+
+            _.each(nbd.edges, _.bind(function (edge) {
+                var edgeKey = JSON.stringify([edge.source.key, edge.target.key]);
+                if (!this.links.has(edgeKey)) {
+                    this.links.add(edgeKey);
+                    newLinks.push(edge);
+                }
+            }, this));
+
+            this.set("nodes", this.get("nodes").concat(newNodes));
+            this.set("links", this.get("links").concat(newLinks));
         }
     });
-}(window.cf, window.Backbone));
+}(window.cf, window.Backbone, window._));

--- a/src/js/lib/preamble.js
+++ b/src/js/lib/preamble.js
@@ -1,0 +1,19 @@
+(function () {
+    "use strict";
+
+    var oldCf,
+        cf;
+
+    // Save old value of cf, just in case.
+    oldCf = window.cf;
+
+    // Establish a namespace for cliquefix.
+    cf = window.cf = {};
+
+    // Return the old value to the previous owner.
+    cf.noConflict = function () {
+        var handle = cf;
+        cf = oldCf;
+        return handle;
+    };
+}());

--- a/src/js/lib/util.js
+++ b/src/js/lib/util.js
@@ -1,0 +1,13 @@
+(function (cf, Hashes) {
+    "use strict";
+
+    cf.util = {};
+
+    cf.util.md5 = (function () {
+        var md5 = new Hashes.MD5();
+
+        return function (s) {
+            return md5.hex(s);
+        };
+    }());
+}(window.cf, window.Hashes));

--- a/src/js/lib/util.js
+++ b/src/js/lib/util.js
@@ -1,4 +1,4 @@
-(function (cf, Hashes) {
+(function (cf, Hashes, _) {
     "use strict";
 
     cf.util = {};
@@ -10,4 +10,26 @@
             return md5.hex(s);
         };
     }());
-}(window.cf, window.Hashes));
+
+    cf.util.Set = function () {
+        var items = {};
+
+        return {
+            add: function (item) {
+                items[item] = null;
+            },
+
+            has: function (item) {
+                return _.has(items, item);
+            },
+
+            items: function (mapper) {
+                var stuff = _.keys(items);
+                if (mapper) {
+                    stuff = _.map(stuff, mapper);
+                }
+                return stuff;
+            }
+        };
+    };
+}(window.cf, window.Hashes, window._));


### PR DESCRIPTION
This implements the basics of a `Graph` class (implemented as a Backbone model), and a basic, in-memory graph data adapter, `NodeLinkList`, that expresses graph structure in a D3ish way.

The `getNeighborhood()` method of the `Graph` class queries its data adapter for a seed graph with the specified center and radius, and merges it into its current model of the graph.  Loading the example application and examining the console will show a two-step example of this in action.
