### PR TITLE
Graph.removeNeighborhood()

### DIFF
--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -11,8 +11,8 @@ head
     link(rel="stylesheet" href="https://bootswatch.com/paper/bootstrap.min.css")
     link(rel="stylesheet" href="index.css")
 
-    script(src="clique.min.js")
-    script(src="index.min.js")
+    script(src="clique.js")
+    script(src="index.js")
 
 body
     nav.navbar.navbar-default

--- a/src/jade/template/selectionInfo.jade
+++ b/src/jade/template/selectionInfo.jade
@@ -15,8 +15,13 @@ mixin item(key, value)
                 li.disabled.next
                     a(aria-label="Next").virtual-link.next
                         span(aria-hidden="true") &raquo;
-        .col-md-1
-            table.table.table-striped.table-bordered
-                +item("key", node.key)
-                for prop in _.filter(_.keys(node), _.negate(_.partial(_.contains, ["key", "root", "index", "x", "y", "variable", "bounds", "fixed", "px", "py"])))
-                    +item(prop, node[prop])
+        .container
+            .row
+                .col-md-1
+                    table.table.table-striped.table-bordered
+                        +item("key", node.key)
+                        for prop in _.filter(_.keys(node), _.negate(_.partial(_.contains, ["key", "root", "index", "x", "y", "variable", "bounds", "fixed", "px", "py"])))
+                            +item(prop, node[prop])
+            .row
+                .col-md-1
+                    button(type="button").btn.btn-danger.btn-sm.remove Remove #[span.glyphicon.glyphicon-remove]

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -61,7 +61,7 @@ $(function () {
         })[0];
 
         if (center) {
-            graph.getNeighborhood({
+            graph.addNeighborhood({
                 center: center,
                 radius: radius
             });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -56,9 +56,9 @@ $(function () {
             return;
         }
 
-        center = graph.findNodes({
+        center = graph.adapter.findNode({
             name: name
-        })[0];
+        });
 
         if (center) {
             graph.addNeighborhood({

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -39,7 +39,7 @@
                 return nodeIndex[key];
             },
 
-            getNeighborhood: function (options) {
+            neighborhood: function (options) {
                 var center,
                     frontier,
                     neighborNodes = new clique.util.Set(),

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -10,13 +10,8 @@
             sourceIndex = {},
             targetIndex = {};
 
-        if (!nodes) {
-            throw clique.error.required("nodes");
-        }
-
-        if (!links) {
-            throw clique.error.required("links");
-        }
+        clique.util.require(nodes, "nodes");
+        clique.util.require(links, "links");
 
         _.each(nodes, function (n) {
             var hash = clique.util.md5(_.uniqueId() + JSON.stringify(n));
@@ -50,13 +45,8 @@
                     neighborNodes = new clique.util.Set(),
                     neighborLinks = new clique.util.Set();
 
-                if (!options.center) {
-                    throw clique.error.required("center");
-                }
-
-                if (_.isUndefined(options.radius)) {
-                    throw clique.error.required("radius");
-                }
+                clique.util.require(options.center, "center");
+                clique.util.require(options.radius, "radius");
 
                 center = nodeIndex[options.center];
                 center.root = true;

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -32,7 +32,11 @@
 
         return {
             findNodes: function (spec) {
-                return _.pluck(_.where(nodes, spec), "key");
+                return _.where(nodes, spec);
+            },
+
+            findNode: function (spec) {
+                return _.findWhere(nodes, spec);
             },
 
             getNode: function (key) {
@@ -40,58 +44,54 @@
             },
 
             neighborhood: function (options) {
-                var center,
-                    frontier,
+                var frontier,
                     neighborNodes = new clique.util.Set(),
                     neighborLinks = new clique.util.Set();
 
                 clique.util.require(options.center, "center");
                 clique.util.require(options.radius, "radius");
 
-                center = nodeIndex[options.center];
-                center.root = true;
+                options.center.root = true;
 
-                if (center) {
-                    neighborNodes.add(center.key);
+                neighborNodes.add(options.center.key);
 
-                    frontier = new clique.util.Set();
-                    frontier.add(center.key);
+                frontier = new clique.util.Set();
+                frontier.add(options.center.key);
 
-                    // Fan out from the center to reach the requested radius.
-                    _.each(_.range(options.radius), function () {
-                        var newFrontier = new clique.util.Set();
+                // Fan out from the center to reach the requested radius.
+                _.each(_.range(options.radius), function () {
+                    var newFrontier = new clique.util.Set();
 
-                        // Find all links to and from the current frontier
-                        // nodes.
-                        _.each(frontier.items(), function (nodeKey) {
-                            _.each(sourceIndex[nodeKey], function (neighborKey) {
-                                neighborLinks.add(JSON.stringify([nodeKey, neighborKey]));
-                            });
-
-                            _.each(targetIndex[nodeKey], function (neighborKey) {
-                                neighborLinks.add(JSON.stringify([neighborKey, nodeKey]));
-                            });
+                    // Find all links to and from the current frontier
+                    // nodes.
+                    _.each(frontier.items(), function (nodeKey) {
+                        _.each(sourceIndex[nodeKey], function (neighborKey) {
+                            neighborLinks.add(JSON.stringify([nodeKey, neighborKey]));
                         });
 
-                        // Collect the nodes named in the links.
-                        _.each(neighborLinks.items(), function (link) {
-                            link = JSON.parse(link);
-
-                            if (!neighborNodes.has(link[0])) {
-                                newFrontier.add(link[0]);
-                            }
-
-                            if (!neighborNodes.has(link[1])) {
-                                newFrontier.add(link[1]);
-                            }
-
-                            neighborNodes.add(link[0]);
-                            neighborNodes.add(link[1]);
+                        _.each(targetIndex[nodeKey], function (neighborKey) {
+                            neighborLinks.add(JSON.stringify([neighborKey, nodeKey]));
                         });
-
-                        frontier = newFrontier;
                     });
-                }
+
+                    // Collect the nodes named in the links.
+                    _.each(neighborLinks.items(), function (link) {
+                        link = JSON.parse(link);
+
+                        if (!neighborNodes.has(link[0])) {
+                            newFrontier.add(link[0]);
+                        }
+
+                        if (!neighborNodes.has(link[1])) {
+                            newFrontier.add(link[1]);
+                        }
+
+                        neighborNodes.add(link[0]);
+                        neighborNodes.add(link[1]);
+                    });
+
+                    frontier = newFrontier;
+                });
 
                 return {
                     nodes: _.map(neighborNodes.items(), _.propertyOf(nodeIndex)),

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -4,8 +4,8 @@
     clique.adapter = {};
 
     clique.adapter.NodeLinkList = function (cfg) {
-        var nodes = cfg.nodes,
-            links = cfg.links,
+        var nodes = clique.util.deepCopy(cfg.nodes),
+            links = clique.util.deepCopy(cfg.links),
             nodeIndex = {},
             sourceIndex = {},
             targetIndex = {};

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -39,10 +39,6 @@
                 return _.findWhere(nodes, spec);
             },
 
-            getNode: function (key) {
-                return nodeIndex[key];
-            },
-
             neighborhood: function (options) {
                 var frontier,
                     neighborNodes = new clique.util.Set(),

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -54,7 +54,7 @@
                     throw clique.error.required("center");
                 }
 
-                if (!options.radius) {
+                if (_.isUndefined(options.radius)) {
                     throw clique.error.required("radius");
                 }
 

--- a/src/js/lib/error.js
+++ b/src/js/lib/error.js
@@ -1,9 +1,0 @@
-(function (clique) {
-    "use strict";
-
-    clique.error = {};
-
-    clique.error.required = function (what) {
-        return new Error("option '" + what + "' is required");
-    };
-}(window.clique));

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -11,8 +11,6 @@
 
             this.adapter = new options.adapter(options.options);
 
-            this.findNodes = _.bind(this.adapter.findNodes, this.adapter);
-
             this.nodes = {};
             this.links = new clique.util.Set();
 

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -7,9 +7,7 @@
         },
 
         initialize: function (attributes, options) {
-            if (!options.adapter) {
-                throw clique.error.required("adapter");
-            }
+            clique.util.require(options.adapter, "adapter");
 
             this.adapter = new options.adapter(options.options);
 

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -20,7 +20,7 @@
             this.set("links", []);
         },
 
-        getNeighborhood: function (options) {
+        addNeighborhood: function (options) {
             var nbd = this.adapter.neighborhood(options),
                 newNodes = [],
                 newLinks = [];

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -15,7 +15,7 @@
 
             this.findNodes = _.bind(this.adapter.findNodes, this.adapter);
 
-            this.nodes = new clique.util.Set();
+            this.nodes = {};
             this.links = new clique.util.Set();
 
             this.set("nodes", []);
@@ -28,8 +28,8 @@
                 newLinks = [];
 
             _.each(nbd.nodes, _.bind(function (node) {
-                if (!this.nodes.has(node.key)) {
-                    this.nodes.add(node.key);
+                if (!_.has(this.nodes, node.key)) {
+                    this.nodes[node.key] = node;
                     newNodes.push(node);
                 }
             }, this));

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -21,7 +21,7 @@
         },
 
         getNeighborhood: function (options) {
-            var nbd = this.adapter.getNeighborhood(options),
+            var nbd = this.adapter.neighborhood(options),
                 newNodes = [],
                 newLinks = [];
 

--- a/src/js/lib/util.js
+++ b/src/js/lib/util.js
@@ -11,12 +11,23 @@
         };
     }());
 
+    clique.util.deepCopy = function (o) {
+        if (_.isUndefined(o)) {
+            return undefined;
+        }
+        return JSON.parse(JSON.stringify(o));
+    };
+
     clique.util.Set = function () {
         var items = {};
 
         return {
             add: function (item) {
                 items[item] = null;
+            },
+
+            remove: function (item) {
+                delete items[item];
             },
 
             has: function (item) {
@@ -29,6 +40,40 @@
                     stuff = _.map(stuff, mapper);
                 }
                 return stuff;
+            }
+        };
+    };
+
+    clique.util.MultiTable = function () {
+        var table = {};
+
+        return {
+            add: function (key, item) {
+                if (!_.has(table, key)) {
+                    table[key] = new clique.util.Set();
+                }
+
+                table[key].add(item);
+            },
+
+            remove: function (key, item) {
+                if (_.has(table, key)) {
+                    table[key].remove(item);
+                }
+            },
+
+            strike: function (key) {
+                delete table[key];
+            },
+
+            has: function (key, item) {
+                return _.has(table, key) && (_.isUndefined(item) || table[key].has(item));
+            },
+
+            items: function (key) {
+                if (_.has(table, key)) {
+                    return table[key].items();
+                }
             }
         };
     };

--- a/src/js/lib/util.js
+++ b/src/js/lib/util.js
@@ -32,4 +32,10 @@
             }
         };
     };
+
+    clique.util.require = function (arg, name) {
+        if (_.isUndefined(arg)) {
+            throw new Error("argument '" + name + "' is required");
+        }
+    };
 }(window.clique, window.Hashes, window._));

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -78,6 +78,13 @@
                     }
                 }, this));
 
+            this.nodes.exit()
+                .transition()
+                .duration(1000)
+                .attr("r", 0)
+                .style("opacity", 0)
+                .remove();
+
             this.links = d3.select(this.el)
                 .select("g.links")
                 .selectAll("line.link")
@@ -93,6 +100,13 @@
                 .transition()
                 .duration(500)
                 .style("stroke-width", 1);
+
+            this.links.exit()
+                .transition()
+                .duration(1000)
+                .style("stroke-width", 0)
+                .style("opacity", 0)
+                .remove();
 
             this.cola.on("tick", _.bind(function () {
                 var width = this.$el.width(),

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -79,6 +79,9 @@
                 }, this));
 
             this.nodes.exit()
+                .each(_.bind(function (d) {
+                    this.selection.remove(d.key);
+                }, this))
                 .transition()
                 .duration(1000)
                 .attr("r", 0)

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -3,13 +3,8 @@
 
     clique.view.Cola = Backbone.View.extend({
         initialize: function (options) {
-            if (!this.model) {
-                throw clique.error.required("model");
-            }
-
-            if (!this.el) {
-                throw clique.error.required("el");
-            }
+            clique.util.require(this.model, "model");
+            clique.util.require(this.el, "el");
 
             options = options || {};
 

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -66,6 +66,10 @@
                 .on("click", function () {
                     that.focusRight();
                 });
+
+            this.$("button.remove").on("click", _.bind(function () {
+                console.log("removing node " + node.key);
+            }, this));
         }
     });
 }(window.clique, window.Backbone, window._, window.d3));

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -32,6 +32,10 @@
             }
         },
 
+        focusNode: function () {
+            return this.model.items()[this.focalPoint];
+        },
+
         render: function () {
             var nodes = this.model.items(),
                 node,
@@ -42,7 +46,7 @@
             }
 
             node = this.graph.adapter.findNode({
-                key: this.model.items()[this.focalPoint]
+                key: this.focusNode()
             });
 
             this.trigger("focus", node && node.key || undefined);

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -33,7 +33,9 @@
         },
 
         focusNode: function () {
-            return this.model.items()[this.focalPoint];
+            return this.graph.adapter.findNode({
+                key: this.model.items()[this.focalPoint]
+            });
         },
 
         render: function () {
@@ -45,9 +47,7 @@
                 this.focalPoint = Math.max(0, _.size(nodes) - 1);
             }
 
-            node = this.graph.adapter.findNode({
-                key: this.focusNode()
-            });
+            node = this.focusNode();
 
             this.trigger("focus", node && node.key || undefined);
 
@@ -74,7 +74,10 @@
                 });
 
             this.$("button.remove").on("click", _.bind(function () {
-                console.log("removing node " + node.key);
+                this.graph.removeNeighborhood({
+                    center: this.focusNode(),
+                    radius: 0
+                });
             }, this));
         }
     });

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -17,6 +17,7 @@
             }
 
             this.listenTo(this.model, "change", this.render);
+            this.listenTo(this.graph, "change", this.render);
         },
 
         focus: function (target) {

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -41,7 +41,9 @@
                 this.focalPoint = Math.max(0, _.size(nodes) - 1);
             }
 
-            node = this.graph.adapter.getNode(this.model.items()[this.focalPoint]);
+            node = this.graph.adapter.findNode({
+                key: this.model.items()[this.focalPoint]
+            });
 
             this.trigger("focus", node && node.key || undefined);
 

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -3,18 +3,13 @@
 
     clique.view.SelectionInfo = Backbone.View.extend({
         initialize: function (options) {
-            if (!this.model) {
-                throw clique.error.required("model");
-            }
+            clique.util.require(this.model, "model");
+            clique.util.require(options.graph, "graph");
 
             this.focalPoint = 0;
 
             options = options || {};
             this.graph = options.graph;
-
-            if (!this.graph) {
-                throw clique.error.required("graph");
-            }
 
             this.listenTo(this.model, "change", this.render);
             this.listenTo(this.graph, "change", this.render);


### PR DESCRIPTION
This implements `Graph.removeNeighborhood()`, which takes a config object as a single argument, with a required `center` property referencing an existing node in the view, and a required `radius` property that gives the neighborhood radius about the center to remove.  Setting the latter to `0` will remove just the `center` node.

This also places a "remove" button that does a 0-radius remove for the focused node in the current selection.

Closes #14.
