### PR TITLE
Graph no longer "jumps" on re-render

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -80,9 +80,4 @@ $(function () {
         graph: graph
     });
     info.render();
-
-    view.listenTo(info, "focus", function (key) {
-        view.focused = key;
-        view.render();
-    });
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -72,7 +72,6 @@ $(function () {
         model: graph,
         el: "#content"
     });
-    view.render();
 
     window.info = info = new clique.view.SelectionInfo({
         model: view.selection,

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -21,8 +21,10 @@
             this.forward = new clique.util.MultiTable();
             this.back = new clique.util.MultiTable();
 
-            this.set("nodes", []);
-            this.set("links", []);
+            this.set({
+                nodes: [],
+                links: []
+            });
         },
 
         addNeighborhood: function (options) {
@@ -49,8 +51,10 @@
                 }
             }, this));
 
-            this.set("nodes", this.get("nodes").concat(newNodes));
-            this.set("links", this.get("links").concat(newLinks));
+            this.set({
+                nodes: this.get("nodes").concat(newNodes),
+                links: this.get("links").concat(newLinks)
+            });
         },
 
         removeNeighborhood: function (options) {

--- a/src/js/lib/model/Selection.js
+++ b/src/js/lib/model/Selection.js
@@ -32,19 +32,22 @@
 
         focus: function (target) {
             this.focalPoint = target;
+            if (this.focalPoint < 0) {
+                this.focalPoint = 0;
+            }
+            if (this.focalPoint >= this.size()) {
+                this.focalPoint = this.size() - 1;
+            }
+
             this.trigger("focused", this.focused());
         },
 
         focusLeft: function () {
-            if (this.focalPoint > 0) {
-                this.focus(this.focalPoint - 1);
-            }
+            this.focus(this.focalPoint - 1);
         },
 
         focusRight: function () {
-            if (this.focalPoint < this.size() - 1) {
-                this.focus(this.focalPoint + 1);
-            }
+            this.focus(this.focalPoint + 1);
         },
 
         focused: function () {

--- a/src/js/lib/model/Selection.js
+++ b/src/js/lib/model/Selection.js
@@ -2,16 +2,49 @@
     "use strict";
 
     clique.model.Selection = Backbone.Model.extend({
+        initialize: function () {
+            this.focalPoint = 0;
+        },
+
         add: function (key) {
             this.set(key, key);
         },
 
         remove: function (key) {
             this.unset(key);
+
+            if (this.focalPoint >= this.size()) {
+                this.focalPoint = Math.max(0, this.size() - 1);
+            }
         },
 
         items: function () {
             return _.keys(this.attributes);
+        },
+
+        focus: function (target) {
+            this.focalPoint = target;
+            this.trigger("focused", this.focused());
+        },
+
+        focusLeft: function () {
+            if (this.focalPoint > 0) {
+                this.focus(this.focalPoint - 1);
+            }
+        },
+
+        focusRight: function () {
+            if (this.focalPoint < this.size() - 1) {
+                this.focus(this.focalPoint + 1);
+            }
+        },
+
+        focused: function () {
+            return this.items()[this.focalPoint];
+        },
+
+        size: function () {
+            return _.size(this.attributes);
         }
     });
 }(window.clique, window.Backbone, window._));

--- a/src/js/lib/model/Selection.js
+++ b/src/js/lib/model/Selection.js
@@ -8,13 +8,21 @@
 
         add: function (key) {
             this.set(key, key);
+            if (this.size()) {
+                this.trigger("focused", this.focused());
+            }
         },
 
         remove: function (key) {
+            var focused = this.focused() === key;
+
             this.unset(key);
 
             if (this.focalPoint >= this.size()) {
                 this.focalPoint = Math.max(0, this.size() - 1);
+                this.trigger("focused", this.focused());
+            } else if (focused) {
+                this.focusLeft();
             }
         },
 

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -20,7 +20,7 @@
 
             this.nodeRadius = options.nodeRadius || 7.5;
 
-            this.transitionTime = 1000;
+            this.transitionTime = 500;
 
             this.cola = cola.d3adaptor()
                 .linkDistance(options.linkDistance || 100)

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -26,6 +26,11 @@
 
             this.$el.html(clique.template.cola());
             this.listenTo(this.model, "change", this.render);
+            this.listenTo(this.selection, "focused", function (focused) {
+                this.nodes.style("fill", function (d) {
+                    return d.key === focused ? "crimson" : "limegreen";
+                });
+            });
         },
 
         render: function () {

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -20,6 +20,8 @@
 
             this.nodeRadius = options.nodeRadius || 7.5;
 
+            this.transitionTime = 1000;
+
             this.cola = cola.d3adaptor()
                 .linkDistance(options.linkDistance || 100)
                 .avoidOverlaps(true)
@@ -82,7 +84,7 @@
                 })
                 .call(drag)
                 .transition()
-                .duration(500)
+                .duration(this.transitionTime)
                 .attr("r", this.nodeRadius);
 
             this.nodes.style("fill", _.bind(fill, this));
@@ -92,7 +94,7 @@
                     this.selection.remove(d.key);
                 }, this))
                 .transition()
-                .duration(1000)
+                .duration(this.transitionTime)
                 .attr("r", 0)
                 .style("opacity", 0)
                 .remove();
@@ -110,12 +112,12 @@
                 .style("stroke-width", 0)
                 .style("stroke", "black")
                 .transition()
-                .duration(500)
+                .duration(this.transitionTime)
                 .style("stroke-width", 1);
 
             this.links.exit()
                 .transition()
-                .duration(1000)
+                .duration(this.transitionTime)
                 .style("stroke-width", 0)
                 .style("opacity", 0)
                 .remove();

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -1,6 +1,16 @@
 (function (clique, Backbone, _, d3, cola) {
     "use strict";
 
+    var fill = function (d) {
+        if (d.key === this.focused) {
+            return "crimson";
+        } else if (d.root) {
+            return "gold";
+        } else {
+            return "limegreen";
+        }
+    };
+
     clique.view.Cola = Backbone.View.extend({
         initialize: function (options) {
             clique.util.require(this.model, "model");
@@ -27,9 +37,8 @@
             this.$el.html(clique.template.cola());
             this.listenTo(this.model, "change", this.render);
             this.listenTo(this.selection, "focused", function (focused) {
-                this.nodes.style("fill", function (d) {
-                    return d.key === focused ? "crimson" : "limegreen";
-                });
+                this.focused = focused;
+                this.nodes.style("fill", _.bind(fill, this));
             });
         },
 
@@ -80,16 +89,7 @@
                 .duration(500)
                 .attr("r", this.nodeRadius);
 
-            this.nodes
-                .style("fill", _.bind(function (d) {
-                    if (d.key === this.focused.key) {
-                        return "crimson";
-                    } else if (d.root) {
-                        return "gold";
-                    } else {
-                        return "limegreen";
-                    }
-                }, this));
+            this.nodes.style("fill", _.bind(fill, this));
 
             this.nodes.exit()
                 .each(_.bind(function (d) {

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -41,8 +41,6 @@
         },
 
         render: function () {
-            console.log("render");
-
             var nodeData = this.model.get("nodes"),
                 linkData = this.model.get("links"),
                 drag,

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -17,12 +17,20 @@
                 .start();
 
             this.selection = new clique.model.Selection();
+            this.focused = {};
+
+            this.listenTo(this.selection, "nodefocus", function (focus) {
+                console.log("focused!", arguments);
+                this.focused = focus;
+            });
 
             this.$el.html(clique.template.cola());
             this.listenTo(this.model, "change", this.render);
         },
 
         render: function () {
+            console.log("render");
+
             var nodeData = this.model.get("nodes"),
                 linkData = this.model.get("links"),
                 drag,
@@ -69,7 +77,7 @@
 
             this.nodes
                 .style("fill", _.bind(function (d) {
-                    if (d.key === this.focused) {
+                    if (d.key === this.focused.key) {
                         return "crimson";
                     } else if (d.root) {
                         return "gold";

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -27,10 +27,8 @@
                 .start();
 
             this.selection = new clique.model.Selection();
-            this.focused = {};
 
             this.listenTo(this.selection, "nodefocus", function (focus) {
-                console.log("focused!", arguments);
                 this.focused = focus;
             });
 

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -62,6 +62,11 @@
                     this.dragging = true;
                 }, this));
 
+            this.nodes.datum(function (d) {
+                d.fixed = true;
+                return d;
+            });
+
             this.nodes.enter()
                 .append("circle")
                 .classed("node", true)
@@ -151,6 +156,13 @@
             }, this));
 
             this.cola.start();
+
+            _.delay( _.bind(function () {
+                this.nodes.datum(function (d) {
+                    d.fixed = false;
+                    return d;
+                });
+            }, this), this.transitionTime + 5);
         }
     });
 }(window.clique, window.Backbone, window._, window.d3, window.cola));

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -6,49 +6,18 @@
             clique.util.require(this.model, "model");
             clique.util.require(options.graph, "graph");
 
-            this.focalPoint = 0;
-
             options = options || {};
             this.graph = options.graph;
 
             this.listenTo(this.model, "change", this.render);
+            this.listenTo(this.model, "focused", this.render);
             this.listenTo(this.graph, "change", this.render);
         },
 
-        focus: function (target) {
-            this.focalPoint = target;
-            this.render();
-            this.trigger("nodefocus", this.focusNode());
-        },
-
-        focusRight: function () {
-            if (this.focalPoint < _.size(this.model.attributes) - 1) {
-                this.focus(this.focalPoint + 1);
-            }
-        },
-
-        focusLeft: function () {
-            if (this.focalPoint > 0) {
-                this.focus(this.focalPoint - 1);
-            }
-        },
-
-        focusNode: function () {
-            return this.graph.adapter.findNode({
-                key: this.model.items()[this.focalPoint]
-            });
-        },
-
         render: function () {
-            var nodes = this.model.items(),
-                node,
-                that = this;
-
-            if (this.focalPoint >= _.size(nodes)) {
-                this.focalPoint = Math.max(0, _.size(nodes) - 1);
-            }
-
-            node = this.focusNode();
+            var node = this.graph.adapter.findNode({
+                key: this.model.focused()
+            });
 
             this.$el.html(clique.template.selectionInfo({
                 node: node
@@ -56,25 +25,25 @@
 
             d3.select(this.el)
                 .select("li.prev")
-                .classed("disabled", this.focalPoint === 0);
+                .classed("disabled", this.model.focalPoint === 0);
 
             this.$("a.prev")
-                .on("click", function () {
-                    that.focusLeft();
-                });
+                .on("click", _.bind(function () {
+                    this.model.focusLeft();
+                }, this));
 
             d3.select(this.el)
                 .select("li.next")
-                .classed("disabled", this.focalPoint === _.size(nodes) - 1);
+                .classed("disabled", this.model.focalPoint === _.size(this.model.attributes) - 1);
 
             this.$("a.next")
-                .on("click", function () {
-                    that.focusRight();
-                });
+                .on("click", _.bind(function () {
+                    this.model.focusRight();
+                }, this));
 
             this.$("button.remove").on("click", _.bind(function () {
                 this.graph.removeNeighborhood({
-                    center: this.focusNode(),
+                    center: this.model.focusNode(),
                     radius: 0
                 });
             }, this));

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -18,6 +18,7 @@
         focus: function (target) {
             this.focalPoint = target;
             this.render();
+            this.trigger("nodefocus", this.focusNode());
         },
 
         focusRight: function () {

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -49,8 +49,6 @@
 
             node = this.focusNode();
 
-            this.trigger("focus", node && node.key || undefined);
-
             this.$el.html(clique.template.selectionInfo({
                 node: node
             }));

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -43,7 +43,9 @@
 
             this.$("button.remove").on("click", _.bind(function () {
                 this.graph.removeNeighborhood({
-                    center: this.model.focusNode(),
+                    center: this.graph.adapter.findNode({
+                        key: this.model.focused()
+                    }),
                     radius: 0
                 });
             }, this));


### PR DESCRIPTION
Closes #12.

This PR also improves some of the selection logic - in particular, selection focus state has been moved to `Selection` so that both `Cola` and `SelectionInfo` can properly listen for focus change events at the correct location and react accordingly.
