### PR TITLE
Writeback

### DIFF
--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -28,7 +28,7 @@ body
         .col-md-3
             .row
                 .col-md-12
-                    h3 Seed Graph
+                    h4 Add neighborhood
                     .container
                         .row
                             .col-md-1 Name
@@ -41,5 +41,5 @@ body
                                 a.btn.btn-default#seed Query
             .row
                 .col-md-12
-                    h3 Node Info
+                    h4 Node Info
                     #info

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -41,5 +41,12 @@ body
                                 a.btn.btn-default#seed Query
             .row
                 .col-md-12
+                    h4 Graph operations
+                    .container
+                        .row
+                            .col-md-1
+                                button(type="button")#save.btn.btn-info.btn-xs Save #[span.glyphicon.glyphicon-save]
+            .row
+                .col-md-12
                     h4 Node Info
                     #info

--- a/src/jade/template/selectionInfo.jade
+++ b/src/jade/template/selectionInfo.jade
@@ -24,6 +24,6 @@ mixin item(key, value)
                             +item(prop, node[prop])
             .row
                 .col-md-1
-                    button(type="button").btn.btn-danger.btn-sm.remove Remove #[span.glyphicon.glyphicon-remove]
+                    button(type="button").btn.btn-danger.btn-xs.remove Remove #[span.glyphicon.glyphicon-remove]
                 .col-md-1
-                    button(type="button").btn.btn-primary.btn-sm.expand Expand #[span.glyphicon.glyphicon-fullscreen]
+                    button(type="button").btn.btn-primary.btn-xs.expand Expand #[span.glyphicon.glyphicon-fullscreen]

--- a/src/jade/template/selectionInfo.jade
+++ b/src/jade/template/selectionInfo.jade
@@ -20,7 +20,7 @@ mixin item(key, value)
                 .col-md-1
                     table.table.table-striped.table-bordered
                         +item("key", node.key)
-                        for prop in _.filter(_.keys(node), _.negate(_.partial(_.contains, ["key", "root", "index", "x", "y", "variable", "bounds", "fixed", "px", "py"])))
+                        for prop in _.filter(_.keys(node), _.negate(_.bind(clique.ignore.has, clique.ignore)))
                             +item(prop, node[prop])
             .row
                 .col-md-1

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -68,6 +68,10 @@ $(function () {
         }
     });
 
+    $("#save").on("click", function () {
+        graph.adapter.write();
+    });
+
     window.view = view = new clique.view.Cola({
         model: graph,
         el: "#content"

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -39,7 +39,7 @@ $(function () {
         view,
         info;
 
-    graphData = randomGraph(26, 0.20);
+    window.graphData = graphData = randomGraph(26, 0.20);
 
     window.graph = graph = new clique.Graph({
         adapter: clique.adapter.NodeLinkList,

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -6,6 +6,7 @@
     clique.adapter.NodeLinkList = function (cfg) {
         var nodes = clique.util.deepCopy(cfg.nodes),
             links = clique.util.deepCopy(cfg.links),
+            orig = cfg,
             nodeIndex = {},
             sourceIndex = {},
             targetIndex = {};
@@ -100,6 +101,11 @@
                         };
                     })
                 };
+            },
+
+            write: function () {
+                orig.nodes = clique.util.deepCopy(nodes);
+                orig.links = clique.util.deepCopy(links);
             }
         };
     };

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -104,8 +104,16 @@
             },
 
             write: function () {
-                orig.nodes = clique.util.deepCopy(nodes);
-                orig.links = clique.util.deepCopy(links);
+                orig.nodes = _.map(nodes, function (n) {
+                    var node = {};
+                    _.map(n, function (value, key) {
+                        if (!clique.ignore.has(key)) {
+                            node[key] = clique.util.deepCopy(value);
+                        }
+                    });
+
+                    return node;
+                });
             }
         };
     };

--- a/src/js/lib/util.js
+++ b/src/js/lib/util.js
@@ -44,6 +44,11 @@
         };
     };
 
+    clique.ignore = new clique.util.Set();
+    _.each(["key", "root", "index", "x", "y", "variable", "bounds", "fixed", "px", "py"], function (val) {
+        clique.ignore.add(val);
+    });
+
     clique.util.MultiTable = function () {
         var table = {};
 


### PR DESCRIPTION
Implements `write()` method in `NodeLinkList` class, to demonstrate the behavior of this method in the `Adapter` interface.

Currently, it is not possible to "test" this feature without changing the code in an artificial way.  To do that, remove `"root"` from [util.js:48](https://github.com/XDATA-Year-3/clique/blob/writeback/src/js/lib/util.js#L48), rebuild Clique, then run the app, and add a neighborhood centered at `a` to the view.  In the console, examine the `graphData` variable, and observe that the first node (`a`) does not have a `root` property.

Now, click the "save" button and examine `graphData` again.  Since the subgraph was rooted at `a`, and Clique uses a normally-hidden `root` property to mark such nodes (to render them differently in the view), you should see that the node has gained a `root` property.

In general, we will be able to use this mechanism to store metadata on the nodes.  The upcoming "hidden node" feature will make actual use of this feature.
