### PR TITLE
Deleted node semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ following methods:
 
 - ``neighborhood(options)`` - computes and returns a subgraph consisting of the
   node ``options.center``, and all nodes lying within distance
-  ``options.radius`` of it.  Typically, ``options.center`` would be supplied via a
-  call to ``findNodes()`` or ``findNode()``.
+  ``options.radius`` of it.  Typically, ``options.center`` would be supplied via
+  a call to ``findNodes()`` or ``findNode()``.  This method, by default, will not
+  include any nodes with a ``deleted`` property set to true; to include these
+  nodes, ``options.deleted`` can be set to ``true``.
 
 - ``write()`` - causes the original source of the graph data to become
   synchronized with any changes made to the graph since loading.  The following

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -37,6 +37,9 @@ body
                             .col-md-1 Radius
                             .col-md-1 #[input#radius]
                         .row
+                            .col-md-12
+                                label #[input(type="checkbox")#delsearch] Include "deleted" nodes in search results
+                        .row
                             .col-md-1
                                 a.btn.btn-default#seed Query
             .row

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -48,5 +48,5 @@ body
                                 button(type="button")#save.btn.btn-info.btn-xs Save #[span.glyphicon.glyphicon-save]
             .row
                 .col-md-12
-                    h4 Node Info
+                    h4 Selection Operations
                     #info

--- a/src/jade/template/selectionInfo.jade
+++ b/src/jade/template/selectionInfo.jade
@@ -23,7 +23,17 @@ mixin item(key, value)
                         for prop in _.filter(_.keys(node), _.negate(_.bind(clique.ignore.has, clique.ignore)))
                             +item(prop, node[prop])
             .row
-                .col-md-1
-                    button(type="button").btn.btn-danger.btn-xs.remove Remove #[span.glyphicon.glyphicon-remove]
-                .col-md-1
-                    button(type="button").btn.btn-primary.btn-xs.expand Expand #[span.glyphicon.glyphicon-fullscreen]
+                h5 Node
+                button(type="button").space-right.btn.btn-info.btn-xs.remove Hide #[span.glyphicon.glyphicon-eye-close]
+                if node.deleted
+                    button(type="button").space-right.btn.btn-danger.btn-xs.delete Undelete #[span.glyphicon.glyphicon-remove]
+                else
+                    button(type="button").space-right.btn.btn-danger.btn-xs.delete Delete #[span.glyphicon.glyphicon-remove]
+                button(type="button").btn.btn-primary.btn-xs.expand Expand #[span.glyphicon.glyphicon-fullscreen]
+
+            if selectionSize > 1
+                .row
+                    h5 Selection
+                    button(type="button").space-right.btn.btn-info.btn-xs.remove-sel Hide #[span.glyphicon.glyphicon-eye-close]
+                    button(type="button").space-right.btn.btn-danger.btn-xs.delete-sel Delete #[span.glyphicon.glyphicon-remove]
+                    button(type="button").btn.btn-primary.btn-xs.expand-sel Expand #[span.glyphicon.glyphicon-fullscreen]

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -50,7 +50,10 @@ $(function () {
         var name = $("#name").val().trim(),
             radiusText = $("#radius").val().trim(),
             radius = Number(radiusText),
+            delsearch = $("#delsearch").prop("checked"),
             center;
+
+        console.log("delsearch", delsearch);
 
         if (name === "" || radiusText === "" || isNaN(radius)) {
             return;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -53,8 +53,6 @@ $(function () {
             delsearch = $("#delsearch").prop("checked"),
             center;
 
-        console.log("delsearch", delsearch);
-
         if (name === "" || radiusText === "" || isNaN(radius)) {
             return;
         }
@@ -66,7 +64,8 @@ $(function () {
         if (center) {
             graph.addNeighborhood({
                 center: center,
-                radius: radius
+                radius: radius,
+                deleted: delsearch
             });
         }
     });

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -50,10 +50,14 @@
 
                 options.center.root = true;
 
-                neighborNodes.add(options.center.key);
-
                 frontier = new clique.util.Set();
-                frontier.add(options.center.key);
+
+                // Don't start the process with a "deleted" node (unless deleted
+                // nodes are specifically allowed).
+                if (options.deleted || !options.center.deleted) {
+                    neighborNodes.add(options.center.key);
+                    frontier.add(options.center.key);
+                }
 
                 // Fan out from the center to reach the requested radius.
                 _.each(_.range(options.radius), function () {
@@ -62,12 +66,18 @@
                     // Find all links to and from the current frontier
                     // nodes.
                     _.each(frontier.items(), function (nodeKey) {
+                        // Do not add links to nodes that are deleted (unless
+                        // deleted nodes are specifically allowed).
                         _.each(sourceIndex[nodeKey], function (neighborKey) {
-                            neighborLinks.add(JSON.stringify([nodeKey, neighborKey]));
+                            if (options.deleted || !nodeIndex[neighborKey].deleted) {
+                                neighborLinks.add(JSON.stringify([nodeKey, neighborKey]));
+                            }
                         });
 
                         _.each(targetIndex[nodeKey], function (neighborKey) {
-                            neighborLinks.add(JSON.stringify([neighborKey, nodeKey]));
+                            if (options.deleted || !nodeIndex[neighborKey].deleted) {
+                                neighborLinks.add(JSON.stringify([neighborKey, nodeKey]));
+                            }
                         });
                     });
 

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -35,7 +35,7 @@
             });
 
             this.$el.html(clique.template.cola());
-            this.listenTo(this.model, "change", this.render);
+            this.listenTo(this.model, "change", _.debounce(this.render, 100));
             this.listenTo(this.selection, "focused", function (focused) {
                 this.focused = focused;
                 this.nodes.style("fill", _.bind(fill, this));

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -14,13 +14,28 @@
             this.listenTo(this.graph, "change", this.render);
         },
 
+        hideNode: function (node) {
+            this.graph.removeNeighborhood({
+                center: node,
+                radius: 0
+            });
+        },
+
+        expandNode: function (node) {
+            this.graph.addNeighborhood({
+                center: node,
+                radius: 1
+            });
+        },
+
         render: function () {
             var node = this.graph.adapter.findNode({
                 key: this.model.focused()
             });
 
             this.$el.html(clique.template.selectionInfo({
-                node: node
+                node: node,
+                selectionSize: this.model.size()
             }));
 
             d3.select(this.el)
@@ -42,21 +57,31 @@
                 }, this));
 
             this.$("button.remove").on("click", _.bind(function () {
-                this.graph.removeNeighborhood({
-                    center: this.graph.adapter.findNode({
-                        key: this.model.focused()
-                    }),
-                    radius: 0
-                });
+                this.hideNode(this.graph.adapter.findNode({
+                    key: this.model.focused()
+                }));
+            }, this));
+
+            this.$("button.remove-sel").on("click", _.bind(function () {
+                _.each(this.model.items(), _.bind(function (key) {
+                    this.hideNode(this.graph.adapter.findNode({
+                        key: key
+                    }));
+                }, this));
             }, this));
 
             this.$("button.expand").on("click", _.bind(function () {
-                this.graph.addNeighborhood({
-                    center: this.graph.adapter.findNode({
-                        key: this.model.focused()
-                    }),
-                    radius: 1
-                });
+                this.expandNode(this.graph.adapter.findNode({
+                    key: this.model.focused()
+                }));
+            }, this));
+
+            this.$("button.expand-sel").on("click", _.bind(function () {
+                _.each(this.model.items(), _.bind(function (key) {
+                    this.expandNode(this.graph.adapter.findNode({
+                        key: key
+                    }));
+                }, this));
             }, this));
         }
     });

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -21,9 +21,15 @@
             });
         },
 
-        deleteNode: function (node) {
-            node.deleted = true;
-            this.hideNode(node);
+        deleteNode: function (node, deleted) {
+            node.deleted = deleted;
+
+            if (node.deleted) {
+                this.hideNode(node);
+            } else {
+                delete node.deleted;
+                this.render();
+            }
         },
 
         expandNode: function (node) {
@@ -76,16 +82,17 @@
             }, this));
 
             this.$("button.delete").on("click", _.bind(function () {
-                this.deleteNode(this.graph.adapter.findNode({
+                var node = this.graph.adapter.findNode({
                     key: this.model.focused()
-                }));
+                });
+                this.deleteNode(node, !node.deleted);
             }, this));
 
             this.$("button.delete-sel").on("click", _.bind(function () {
                 _.each(this.model.items(), _.bind(function (key) {
                     this.deleteNode(this.graph.adapter.findNode({
                         key: key
-                    }));
+                    }), true);
                 }, this));
             }, this));
 

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -21,6 +21,11 @@
             });
         },
 
+        deleteNode: function (node) {
+            node.deleted = true;
+            this.hideNode(node);
+        },
+
         expandNode: function (node) {
             this.graph.addNeighborhood({
                 center: node,
@@ -65,6 +70,20 @@
             this.$("button.remove-sel").on("click", _.bind(function () {
                 _.each(this.model.items(), _.bind(function (key) {
                     this.hideNode(this.graph.adapter.findNode({
+                        key: key
+                    }));
+                }, this));
+            }, this));
+
+            this.$("button.delete").on("click", _.bind(function () {
+                this.deleteNode(this.graph.adapter.findNode({
+                    key: this.model.focused()
+                }));
+            }, this));
+
+            this.$("button.delete-sel").on("click", _.bind(function () {
+                _.each(this.model.items(), _.bind(function (key) {
+                    this.deleteNode(this.graph.adapter.findNode({
                         key: key
                     }));
                 }, this));

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -7,3 +7,6 @@
 .selected
     stroke blue
     stroke-width 2px
+
+.space-right
+    margin-right 5px


### PR DESCRIPTION
Nodes can now be deleted by setting a `deleted` property on the nodal data.  The UI now includes buttons to carry out deletion/undeletion, and the Adapter interface's `neighborhood()` method now by default will not return any deleted nodes in its results.  This behavior can be overridden by including a `deleted` option, set to `true`, in the configuration object passed to `neighborhood()`.
