### PR TITLE
Selection

### DIFF
--- a/src/js/lib/model/Selection.js
+++ b/src/js/lib/model/Selection.js
@@ -30,6 +30,16 @@
             return _.keys(this.attributes);
         },
 
+        focusKey: function (target) {
+            var index = _.indexOf(this.items(), target);
+            if (index === -1) {
+                return false;
+            }
+
+            this.focus(index);
+            return true;
+        },
+
         focus: function (target) {
             this.focalPoint = target;
             if (this.focalPoint < 0) {

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -258,7 +258,7 @@
                     // Update the view.
                     that.nodes
                         .classed("selected", _.property("selected"))
-                        .style("fill", fill);
+                        .style("fill", _.bind(fill, that));
                 });
 
                 endBrush = function () {
@@ -276,7 +276,7 @@
                         // Update the view.
                         that.nodes
                             .classed("selected", false)
-                            .style("fill", fill);
+                            .style("fill", _.bind(fill, that));
                     }
 
                     dragging = false;

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -232,8 +232,19 @@
                     y = d3.event.pageY - origin.top;
 
                     // Resize the rect to reflect the current mouse position
-                    selector.attr("width", x - start.x)
-                       .attr("height", y - start.y);
+                    if (x > start.x) {
+                        selector.attr("width", x - start.x);
+                    } else {
+                        selector.attr("width", start.x - x)
+                            .attr("x", x);
+                    }
+
+                    if (y > start.y) {
+                        selector.attr("height", y - start.y);
+                    } else {
+                        selector.attr("height", start.y - y)
+                            .attr("y", y);
+                    }
 
                     // Compute which nodes are inside the rect
                     _.each(that.model.get("nodes"), function (node) {

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -74,9 +74,27 @@
                 .style("fill", "limegreen")
                 .on("click", function (d) {
                     var me = d3.select(this),
-                        selected = !me.classed("selected");
+                        selected;
 
                     if (!that.dragging) {
+                        if (d3.event.shiftKey) {
+                            // If the shift key is pressed, then simply toggle
+                            // the presence of the clicked node in the current
+                            // selection.
+                            selected = !me.classed("selected");
+                        } else {
+                            // If the shift key isn't pressed, then clear the
+                            // selection before doing anything else.
+                            _.each(that.selection.items(), function (key) {
+                                that.selection.remove(key);
+                            });
+
+                            d3.select(that.el)
+                                .selectAll("circle.node")
+                                .classed("selected", false);
+                            selected = true;
+                        }
+
                         me.classed("selected", selected);
 
                         if (selected) {

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -220,10 +220,12 @@
                     // Record whether the nodes were selected or not at the time
                     // of the action (if shift is pressed) - this allows for the
                     // current selection to be "sticky" for this operation.
-                    that.nodes.datum(function (d) {
-                        d.keep = shift && d3.select(this).classed("selected");
-                        return d;
-                    });
+                    if (shift) {
+                        that.nodes.datum(function (d) {
+                            d.orig = d3.select(this).classed("selected");
+                            return d;
+                        });
+                    }
                 });
 
                 me.on("mousemove", function () {
@@ -268,7 +270,18 @@
 
                     // Compute which nodes are inside the rect
                     _.each(that.model.get("nodes"), function (node) {
-                        node.selected = node.keep || between(node.x, start.x, x) && between(node.y, start.y, y);
+                        var inside = between(node.x, start.x, x) && between(node.y, start.y, y);
+
+                        if (shift) {
+                            // If shift-brushing, then invert the selection
+                            // state from the original.
+                            node.selected = inside ? !node.orig : node.orig;
+                        } else {
+                            // If brushing (no shift pressed), then select
+                            // everything inside the box and deselect everything
+                            // outside.
+                            node.selected = inside;
+                        }
 
                         if (node.selected) {
                             that.selection.add(node.key);

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -30,10 +30,6 @@
 
             this.selection = new clique.model.Selection();
 
-            this.listenTo(this.selection, "nodefocus", function (focus) {
-                this.focused = focus;
-            });
-
             this.$el.html(clique.template.cola());
             this.listenTo(this.model, "change", _.debounce(this.render, 100));
             this.listenTo(this.selection, "focused", function (focused) {

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -72,11 +72,12 @@
                 .classed("node", true)
                 .attr("r", 0)
                 .style("fill", "limegreen")
+                .on("mousedown.signal", _.bind(function () {
+                    d3.event.stopPropagation();
+                }, this))
                 .on("click", function (d) {
                     var me = d3.select(this),
                         selected;
-
-                    d3.event.stopPropagation();
 
                     if (!that.dragging) {
                         if (d3.event.shiftKey) {

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -185,6 +185,7 @@
                         x: null,
                         y: null
                     },
+                    endBrush,
                     between = function (val, low, high) {
                         var tmp;
 
@@ -264,9 +265,10 @@
                         .style("fill", fill);
                 });
 
-                me.on("mouseup", function () {
+                endBrush = function () {
                     if (dragging) {
-                        selector.remove();
+                        me.selectAll(".selector")
+                            .remove();
                         selector = null;
                     } else if (active) {
                         // If this was merely a click (no dragging), then also
@@ -283,7 +285,10 @@
 
                     dragging = false;
                     active = false;
-                });
+                };
+
+                me.on("mouseup", endBrush)
+                    .on("mouseleave", endBrush);
             }());
 
             this.cola.start();

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -287,8 +287,12 @@
                     active = false;
                 };
 
-                me.on("mouseup", endBrush)
-                    .on("mouseleave", endBrush);
+                // On mouseup, regardless of where the mouse is (as taken care
+                // of by the second handler below), go ahead and terminate the
+                // brushing movement.
+                me.on("mouseup", endBrush);
+                d3.select(document)
+                    .on("mouseup", endBrush);
             }());
 
             this.cola.start();

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -81,6 +81,17 @@
                             // the presence of the clicked node in the current
                             // selection.
                             selected = !me.classed("selected");
+                        } else if (d3.event.ctrlKey) {
+                            // If the control key is pressed, then move the
+                            // focus to the clicked node, adding it to the
+                            // selection first if necessary.
+                            if (!me.classed("selected")) {
+                                me.classed("selected", true);
+                                that.selection.add(d.key);
+                            }
+
+                            that.selection.focusKey(d.key);
+                            return;
                         } else {
                             // If the shift key isn't pressed, then clear the
                             // selection before doing anything else.


### PR DESCRIPTION
- Clicking on a node creates a singleton selection of just that node
- Shift-clicking on a node toggles that node's presence in the current selection
- Click-and-drag (i.e., brushing) creates a new selection comprising the nodes present inside the selector box when the mouse button is released
- Shift-click-and-drag (i.e., shift-brushing) adds to the current selection all nodes present inside the selector box when the mouse button is released
- Control-clicking on a node moves the focus to the clicked node

Closes #22
Closes #23
Closes #35
Closes #36
Closes #37
