### PR TITLE
Wrap selection around "ends" in the obvious way

### DIFF
--- a/src/jade/template/selectionInfo.jade
+++ b/src/jade/template/selectionInfo.jade
@@ -9,10 +9,10 @@ mixin item(key, value)
     else
         nav
             ul.pagination
-                li.disabled.prev
+                li.prev
                     a(aria-label="Previous").virtual-link.prev
                         span(aria-hidden="true") &laquo;
-                li.disabled.next
+                li.next
                     a(aria-label="Next").virtual-link.next
                         span(aria-hidden="true") &raquo;
         .container

--- a/src/js/lib/model/Selection.js
+++ b/src/js/lib/model/Selection.js
@@ -43,10 +43,11 @@
         focus: function (target) {
             this.focalPoint = target;
             if (this.focalPoint < 0) {
-                this.focalPoint = 0;
-            }
-            if (this.focalPoint >= this.size()) {
-                this.focalPoint = this.size() - 1;
+                while (this.focalPoint < 0) {
+                    this.focalPoint += this.size();
+                }
+            } else if (this.focalPoint >= this.size()) {
+                this.focalPoint = this.focalPoint % this.size();
             }
 
             this.trigger("focused", this.focused());

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -1,4 +1,4 @@
-(function (clique, Backbone, _, d3) {
+(function (clique, Backbone, _) {
     "use strict";
 
     clique.view.SelectionInfo = Backbone.View.extend({
@@ -49,18 +49,10 @@
                 selectionSize: this.model.size()
             }));
 
-            d3.select(this.el)
-                .select("li.prev")
-                .classed("disabled", this.model.focalPoint === 0);
-
             this.$("a.prev")
                 .on("click", _.bind(function () {
                     this.model.focusLeft();
                 }, this));
-
-            d3.select(this.el)
-                .select("li.next")
-                .classed("disabled", this.model.focalPoint === _.size(this.model.attributes) - 1);
 
             this.$("a.next")
                 .on("click", _.bind(function () {
@@ -111,4 +103,4 @@
             }, this));
         }
     });
-}(window.clique, window.Backbone, window._, window.d3));
+}(window.clique, window.Backbone, window._));


### PR DESCRIPTION
This causes the selection stepper buttons to never be disabled.  When the selection is at one of the two "ends" (i.e., index `0` or `size() - 1`), the buttons will wrap around the selection to the other end in the obvious way.

Closes #40
