### PR TITLE
Fix brushing

### DIFF
--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -301,17 +301,18 @@
                         me.selectAll(".selector")
                             .remove();
                         selector = null;
-                    } else if (active) {
-                        // If this was merely a click (no dragging), then also
-                        // unselect everything.
+                    } else if (active && !shift) {
+                        // If this was merely a click (no dragging and no shift
+                        // key), then also unselect everything.
                         _.each(that.model.get("nodes"), function (node) {
                             that.selection.remove(node.key);
+                            node.selected = false;
                         });
 
                         // Update the view.
                         that.nodes
-                            .classed("selected", function () {
-                                return shift ? d3.select(this).classed("selected") : false;
+                            .classed("selected", function (d) {
+                                return d.selected;
                             })
                             .style("fill", _.bind(fill, that));
                     }

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -285,7 +285,7 @@
 
                         if (node.selected) {
                             that.selection.add(node.key);
-                        } else if (!shift) {
+                        } else {
                             that.selection.remove(node.key);
                         }
                     });

--- a/src/js/lib/view/SelectionInfo.js
+++ b/src/js/lib/view/SelectionInfo.js
@@ -15,6 +15,8 @@
         },
 
         hideNode: function (node) {
+            node.selected = false;
+            delete node.root;
             this.graph.removeNeighborhood({
                 center: node,
                 radius: 0

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -4,9 +4,5 @@
 .full-width
     width 100%
 
-.selected
-    stroke blue
-    stroke-width 2px
-
 .space-right
     margin-right 5px


### PR DESCRIPTION
This fixes two bugs introduced in #38:
- Brushing over a selected node made the node appear to be deselected but didn't actually remove it from the selection
- Going by the general semantics of holding down shift while performing mouse actions, shift-clicking on the background should not change the current selection in any way (to see why, consider the quantum of mouse activity beyond a simple shift-click - that would be a shift-click-drag of a small, empty selector box, which also would not change the current selection).
