### PR TITLE
Fixing catch-22 user interaction problem with panel displays

### DIFF
--- a/src/jade/template/selectionInfo.jade
+++ b/src/jade/template/selectionInfo.jade
@@ -18,7 +18,7 @@ mixin item(key, value)
         .container.full-width
             .row
                 .col-md-1
-                    table.table.table-striped.table-bordered
+                    table.table.table-striped.table-bordered.select-ok
                         +item("key", node.key())
                         for item in node.getAllData()
                             +item(item[0], item[1])

--- a/src/jade/template/selectionInfo.jade
+++ b/src/jade/template/selectionInfo.jade
@@ -3,7 +3,7 @@ mixin item(key, value)
         td.text-right: strong= key
         td= value
 
-.container.noclick
+.container.full-width
     if _.isUndefined(node)
         em (Selection is empty)
     else
@@ -15,7 +15,7 @@ mixin item(key, value)
                 li.next
                     a(aria-label="Next").virtual-link.next
                         span(aria-hidden="true") &raquo;
-        .container.noclick
+        .container.full-width
             .row
                 .col-md-1
                     table.table.table-striped.table-bordered

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -1,9 +1,6 @@
 .virtual-link
     cursor pointer
 
-.noclick
-    pointer-events none
-
 .full-width
     width 100%
 

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -25,6 +25,9 @@ user-select(args...)
 .clique-panel .panel-heading a
     text-decoration none
 
+.select-ok
+    user-select text
+
 html, body
     height 100%
 


### PR DESCRIPTION
A div in the control panel was so long that it spilled over into the graph display, intercepting mouse events and making graph interaction impossible.

The hack to fix this was to set `pointer-events:none` on the offending elements, which prevented access to the expand/delete/hide buttons they contained.

The fix is to rely on parent elements being positioned, and setting the offending div widths to `100%`.
