### PR TITLE
Handle directed and bidirectional links in rendering

### DIFF
--- a/data/csv2json.py
+++ b/data/csv2json.py
@@ -17,18 +17,24 @@ def emit_node(node):
 
 
 def emit_link(link, source, target, bi=False):
-    print bson.json_util.dumps({"_id": ObjectId(),
-                                "type": "link",
-                                "source": source,
-                                "target": target,
-                                "data": link})
+    oid = ObjectId()
+    output = {"_id": oid,
+              "type": "link",
+              "source": source,
+              "target": target,
+              "data": link}
+    if bi:
+        output["data"]["bidir"] = True
+
+    print bson.json_util.dumps(output)
 
     if bi:
         print bson.json_util.dumps({"_id": ObjectId(),
                                     "type": "link",
+                                    "data": {"bidir": True,
+                                             "reference": oid},
                                     "source": target,
-                                    "target": source,
-                                    "data": link})
+                                    "target": source})
 
 
 def make_node_record(filename=None, label=None, semtype=None, card=None, attr=None):

--- a/data/multilinkTest.py
+++ b/data/multilinkTest.py
@@ -1,0 +1,82 @@
+import bson.json_util
+from bson.objectid import ObjectId
+
+import sys
+
+
+def main():
+    node1 = ObjectId()
+    print bson.json_util.dumps({"_id": node1,
+                                "type": "node",
+                                "data": {"foo": "bar"}})
+
+    node2 = ObjectId()
+    print bson.json_util.dumps({"_id": node2,
+                                "type": "node",
+                                "data": {"foo": "bar"}})
+
+
+    link1 = ObjectId()
+    print bson.json_util.dumps({"_id": link1,
+                                "type": "link",
+                                "source": node1,
+                                "target": node2,
+                                "data": {"bidir": True}})
+
+    link2 = ObjectId()
+    print bson.json_util.dumps({"_id": link2,
+                                "type": "link",
+                                "source": node1,
+                                "target": node2,
+                                "data": {"bidir": True}})
+
+    link3 = ObjectId()
+    print bson.json_util.dumps({"_id": link3,
+                                "type": "link",
+                                "source": node1,
+                                "target": node2})
+
+    link4 = ObjectId()
+    print bson.json_util.dumps({"_id": link4,
+                                "type": "link",
+                                "source": node2,
+                                "target": node1})
+
+    node5 = ObjectId()
+    print bson.json_util.dumps({"_id": node5,
+                                "type": "node",
+                                "data": {"foo": "bar"}})
+
+    node6 = ObjectId()
+    print bson.json_util.dumps({"_id": node6,
+                                "type": "node",
+                                "data": {"foo": "bar"}})
+
+
+    link5 = ObjectId()
+    print bson.json_util.dumps({"_id": link5,
+                                "type": "link",
+                                "source": node5,
+                                "target": node6})
+
+    link6 = ObjectId()
+    print bson.json_util.dumps({"_id": link6,
+                                "type": "link",
+                                "source": node5,
+                                "target": node6,
+                                "data": {"bidir": True}})
+
+    link7 = ObjectId()
+    print bson.json_util.dumps({"_id": link7,
+                                "type": "link",
+                                "source": node5,
+                                "target": node6})
+
+    link8 = ObjectId()
+    print bson.json_util.dumps({"_id": link8,
+                                "type": "link",
+                                "source": node6,
+                                "target": node5})
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -170,9 +170,9 @@
                 .classed("link", true);
 
             groups.append("path")
-                .style("fill", "none")
+                .style("fill", "lightslategray")
                 .style("stroke-width", 0)
-                .style("stroke", "black")
+                .style("stroke", "lightslategray")
                 .style("stroke-dasharray", function (d) {
                     return d.data && d.data.grouping ? "5,5" : "none";
                 })
@@ -183,7 +183,7 @@
             groups.append("path")
                 .style("fill", "none")
                 .classed("handle", true)
-                .style("stroke-width", 10)
+                .style("stroke-width", 7)
                 .on("mouseenter", function () {
                     d3.select(this)
                         .classed("hovering", true);
@@ -325,6 +325,9 @@
                         var multiplier,
                             dx,
                             dy,
+                            invLen,
+                            offset,
+                            thickness = 1.0,
                             control,
                             path,
                             point;
@@ -343,10 +346,26 @@
                             y: d.source.y + 0.5*dy + multiplier * -dx
                         };
 
-                        path = [
-                            "M", point(d.source.x, d.source.y),
-                            "Q", point(control.x, control.y), point(d.target.x, d.target.y)
-                        ];
+                        invLen = 1.0 / Math.sqrt(dx*dx + dy*dy);
+                        offset = {
+                            x: dy * invLen * 5,
+                            y: -dx * invLen * 5
+                        };
+
+                        if (d.linkRank === 0) {
+                            path = [
+                                "M", point(d.source.x + 0.5 * thickness * offset.x, d.source.y + 0.5 * thickness * offset.y),
+                                "L", point(d.target.x, d.target.y),
+                                "L", point(d.source.x - 0.5 * thickness * offset.x, d.source.y - 0.5 * thickness * offset.y)
+                            ];
+                        } else {
+                            path = [
+                                "M", point(d.source.x + thickness * offset.x, d.source.y + thickness * offset.y),
+                                "Q", point(control.x, control.y), point(d.target.x, d.target.y),
+                                "Q", point(control.x, control.y), point(d.source.x, d.source.y)
+                            ];
+                        }
+
                         return path.join(" ");
                     });
             }, this));

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -328,6 +328,7 @@
                             invLen,
                             offset,
                             thickness = 1.0,
+                            flip,
                             control,
                             path,
                             point;
@@ -337,6 +338,7 @@
                         };
 
                         multiplier = 0.15 * (d.linkRank % 2 === 0 ? -d.linkRank / 2 : (d.linkRank + 1) / 2);
+                        flip = d.linkRank % 2 === 0 ? -1.0 : 1.0;
 
                         dx = d.target.x - d.source.x;
                         dy = d.target.y - d.source.y;
@@ -348,8 +350,8 @@
 
                         invLen = 1.0 / Math.sqrt(dx*dx + dy*dy);
                         offset = {
-                            x: dy * invLen * 5,
-                            y: -dx * invLen * 5
+                            x: flip * dy * invLen * 5,
+                            y: flip * -dx * invLen * 5
                         };
 
                         if (d.linkRank === 0) {

--- a/src/js/lib/view/Cola.js
+++ b/src/js/lib/view/Cola.js
@@ -176,14 +176,15 @@
 
             groups.append("path")
                 .style("fill", "lightslategray")
-                .style("stroke-width", 0)
+                .style("opacity", 0.0)
+                .style("stroke-width", 1)
                 .style("stroke", "lightslategray")
                 .style("stroke-dasharray", function (d) {
                     return d.data && d.data.grouping ? "5,5" : "none";
                 })
                 .transition()
                 .duration(this.transitionTime)
-                .style("stroke-width", 1);
+                .style("opacity", 1.0);
 
             groups.append("path")
                 .style("fill", "none")


### PR DESCRIPTION
- Render directed links as tapering lines to indicate direction
- Use constant-width lines for bidirectional links
  - bidirectional links are now marked by including a `bidir` data property, set to `true`, in the link metadata
  - if a bidirectional link also includes a `reference` data property, it indicates that the link metadata can be found in the link whose key is mentioned in that property (this allows the degree of both nodes to be computed correctly)
