### PR TITLE
Autocomplete on "field name" and "value" inputs in flexible search UI

### DIFF
--- a/data/unique-fields/map.js
+++ b/data/unique-fields/map.js
@@ -1,0 +1,11 @@
+function () {
+    var key;
+
+    if (this.data) {
+        for (key in this.data) {
+            if (this.data.hasOwnProperty(key)) {
+                emit(key, 1);
+            }
+        }
+    }
+}

--- a/data/unique-fields/reduce.js
+++ b/data/unique-fields/reduce.js
@@ -1,0 +1,3 @@
+function (key, values) {
+    return Array.sum(values);
+}

--- a/data/unique-fields/unique-fields.py
+++ b/data/unique-fields/unique-fields.py
@@ -1,0 +1,23 @@
+from pymongo import MongoClient
+import sys
+
+
+def main():
+    if len(sys.argv) < 3:
+        print >>sys.stderr, "usage: unique-fields.py <hostname> <database> <collection>"
+        return 1
+
+    host = sys.argv[1]
+    db = sys.argv[2]
+    coll = sys.argv[3]
+
+    m = MongoClient(host)[db][coll]
+
+    mapFunction = open("map.js").read()
+    reduceFunction = open("reduce.js").read()
+
+    result = m.map_reduce(mapFunction, reduceFunction, "%s.fields" % (coll))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/assets/tangelo/anb/get_fieldnames.py
+++ b/src/assets/tangelo/anb/get_fieldnames.py
@@ -1,0 +1,10 @@
+from pymongo import MongoClient
+
+
+def run(host=None, db=None, coll=None):
+    client = MongoClient(host)
+    db = client[db]
+    graph = db["%s.fields" % (coll)]
+
+    # Reverse sort the entries by frequency.
+    return map(lambda x: x["_id"], sorted(graph.find(), lambda x, y: int(y["value"]) - int(x["value"])))

--- a/src/assets/tangelo/anb/get_values.py
+++ b/src/assets/tangelo/anb/get_values.py
@@ -1,0 +1,9 @@
+from pymongo import MongoClient
+
+
+def run(host=None, db=None, coll=None, field=None):
+    client = MongoClient(host)
+    db = client[db]
+    graph = db[coll]
+
+    return sorted(list(set(map(lambda x: x["data"][field], graph.find({"type": "node", "data.%s" % (field): {"$exists": 1}})))))

--- a/src/js/anb.js
+++ b/src/js/anb.js
@@ -6,7 +6,8 @@ $(function () {
 
     var parser,
         removeAlert,
-        createAlert;
+        createAlert,
+        cfg;
 
     $("#add-clause").on("show.bs.modal", function () {
         var emptyQuery;
@@ -16,6 +17,21 @@ $(function () {
         emptyQuery = _.size($("#query-string").val().trim()) === 0;
         d3.select("#clause-type")
             .style("display", emptyQuery ? "none" : null);
+
+        // Query the database for all available field names, and construct an
+        // autocomplete menu from them.
+        $.getJSON("assets/tangelo/anb/get_fieldnames", {
+            host: cfg.host,
+            db: cfg.database,
+            coll: cfg.collection
+        }).then(function (fields) {
+            $("#fieldname").autocomplete({
+                source: fields,
+                minLength: 0
+            }).focus(function () {
+                $(this).autocomplete("search", $(this).val());
+            });
+        });
     });
 
     removeAlert = function (selector) {
@@ -85,11 +101,13 @@ $(function () {
         $("#add-clause").modal("hide");
     });
 
-    var launch = function (cfg) {
+    var launch = function (_cfg) {
         var graph,
             view,
             info,
             linkInfo;
+
+        cfg = _cfg;
 
         window.graph = graph = new clique.Graph({
             adapter: tangelo.getPlugin("mongo").Mongo,

--- a/src/js/anb.js
+++ b/src/js/anb.js
@@ -45,21 +45,30 @@ $(function () {
                 field = $("#fieldname").val();
             }
 
-            // Pass the field name to the value service in order to get a list
-            // of possible values.
-            $.getJSON("assets/tangelo/anb/get_values", {
-                host: cfg.host,
-                db: cfg.database,
-                coll: cfg.collection,
-                field: field
-            }).then(function (values) {
-                $("#value").autocomplete({
-                    source: values,
-                    minLength: 0
-                }).focus(function () {
-                    $(this).autocomplete("search", $(this).val());
+            field = field.trim();
+            if (field !== "") {
+                // Pass the field name to the value service in order to get a
+                // list of possible values.
+                $.getJSON("assets/tangelo/anb/get_values", {
+                    host: cfg.host,
+                    db: cfg.database,
+                    coll: cfg.collection,
+                    field: field
+                }).then(function (values) {
+                    $("#value").autocomplete({
+                        source: values,
+                        minLength: 0
+                    }).focus(function () {
+                        var $this = $(this);
+
+                        if ($this.data("ui-autocomplete")) {
+                            $(this).autocomplete("search", $(this).val());
+                        }
+                    });
                 });
-            });
+            } else {
+                $("#value").autocomplete("destroy");
+            }
         }, 200);
 
         // Trigger the secondary autocomplete population on both manual typing

--- a/src/js/anb.js
+++ b/src/js/anb.js
@@ -9,8 +9,11 @@ $(function () {
         createAlert;
 
     $("#add-clause").on("show.bs.modal", function () {
-        var emptyQuery = _.size($("#query-string").val().trim()) === 0;
+        var emptyQuery;
 
+        // If the query string is currently empty, then remove the logical
+        // connective from the UI.
+        emptyQuery = _.size($("#query-string").val().trim()) === 0;
         d3.select("#clause-type")
             .style("display", emptyQuery ? "none" : null);
     });

--- a/src/js/anb.js
+++ b/src/js/anb.js
@@ -10,7 +10,8 @@ $(function () {
         cfg;
 
     $("#add-clause").on("show.bs.modal", function () {
-        var emptyQuery;
+        var emptyQuery,
+            secondary;
 
         // If the query string is currently empty, then remove the logical
         // connective from the UI.
@@ -32,6 +33,39 @@ $(function () {
                 $(this).autocomplete("search", $(this).val());
             });
         });
+
+        // This function extracts the field name from the appropriate place - it
+        // winds up in different locations for different triggering events.
+        secondary = _.debounce(function (evt, ui) {
+            var field;
+
+            if (ui) {
+                field = ui.item.value;
+            } else {
+                field = $("#fieldname").val();
+            }
+
+            // Pass the field name to the value service in order to get a list
+            // of possible values.
+            $.getJSON("assets/tangelo/anb/get_values", {
+                host: cfg.host,
+                db: cfg.database,
+                coll: cfg.collection,
+                field: field
+            }).then(function (values) {
+                $("#value").autocomplete({
+                    source: values,
+                    minLength: 0
+                }).focus(function () {
+                    $(this).autocomplete("search", $(this).val());
+                });
+            });
+        }, 200);
+
+        // Trigger the secondary autocomplete population on both manual typing
+        // and selecting a choice from the primary autocomplete menu.
+        $("#fieldname").on("input", secondary);
+        $("#fieldname").on("autocompleteselect", secondary);
     });
 
     removeAlert = function (selector) {

--- a/src/styl/index.styl
+++ b/src/styl/index.styl
@@ -60,6 +60,7 @@ user-select(args...)
     max-width 300px
     overflow-y auto
     overflow-x hidden
+    z-index 1100
 
 html, body
     height 100%


### PR DESCRIPTION
This PR implements the following sequence of behavior:
- When the "add search clause" modal UI is engaged, Clique asks the Mongo server for a list of field names that occur in the database.  These are stored as documents with the following structure:
  `{
  "_id": "<field name>",
  "value": <count of field name in collection>
  }`. They are stored in the same database as the main collection, in a separate collection named by appending `.fields` to the name of the main collection.  The fields are then populated into an autocomplete menu on the "field name" input.
- When the user either types in a field name, or selects one from the autocomplete menu, Clique sends a query to the collection asking for all values associated to the chosen field name.  These are populated into a secondary autocomplete menu on the "value" field.  If the field name is blank, Clique instead removes any existing autocomplete menu from the "value" field.

TODO:
- When metadata is changed via the data adapter, the fields collection should be updated appropriately, removing any field entries whose count may have dropped to 0.
