### PR TITLE
Excluding distribution JS files from diff/grep

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+clique*.js -diff

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 build
 node_modules
 bower_components
-clique.js
-clique.min.js


### PR DESCRIPTION
These files will no longer show up either in the results of "git grep" or "git
diff".

Furthermore, there's no point in naming these files in .gitignore, since they are tracked by Git.
