### PR TITLE
Rename functions

### DIFF
--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -88,11 +88,11 @@
         this.getAccessor = _.propertyOf(accessors);
 
         this.findNodes = function (spec) {
-            return $.when(this.findNodesImpl(spec)).then(_.partial(_.map, _, this.addAccessor, this));
+            return $.when(this.findNodesRaw(spec)).then(_.partial(_.map, _, this.addAccessor, this));
         };
 
         this.findNode = function (spec) {
-            return $.when(this.findNodesImpl(spec)).then(_.bind(function (results) {
+            return $.when(this.findNodesRaw(spec)).then(_.bind(function (results) {
                 if (_.isEmpty(results)) {
                     return undefined;
                 }
@@ -117,11 +117,11 @@
             delete spec.source;
             delete spec.target;
 
-            return $.when(this.findLinksImpl(spec, source, target, directed)).then(_.partial(_.map, _, this.addAccessor, this));
+            return $.when(this.findLinksRaw(spec, source, target, directed)).then(_.partial(_.map, _, this.addAccessor, this));
         };
 
         this.findLink = function (spec) {
-            return $.when(this.findLinksImpl(spec)).then(_.bind(function (results) {
+            return $.when(this.findLinksRaw(spec)).then(_.bind(function (results) {
                 if (_.isEmpty(results)) {
                     return undefined;
                 }
@@ -436,7 +436,7 @@
         };
 
         this.createNode = function (data) {
-            return $.when(this.createNodeImpl(data || {}))
+            return $.when(this.createNodeRaw(data || {}))
                 .then(_.bind(this.addAccessor, this));
         };
 
@@ -451,13 +451,13 @@
             data = _data || {};
             undirected = _.isUndefined(undirected) ? false : undirected;
 
-            return $.when(this.createLinkImpl(source, target, data, undirected))
+            return $.when(this.createLinkRaw(source, target, data, undirected))
                 .then(_.bind(this.addAccessor, this));
         };
 
         this.destroyNode = function (node) {
             var key = node.key();
-            return this.destroyNodeImpl(key).then(function (response) {
+            return this.destroyNodeRaw(key).then(function (response) {
                 return {
                     key: key,
                     response: response
@@ -467,7 +467,7 @@
 
         this.destroyLink = function (link) {
             var key = link.key();
-            return this.destroyLinkImpl(key).then(function (response) {
+            return this.destroyLinkRaw(key).then(function (response) {
                 return {
                     key: key,
                     response: response
@@ -531,7 +531,7 @@
             }, this);
         },
 
-        findNodesImpl: function (_spec) {
+        findNodesRaw: function (_spec) {
             var spec = clique.util.deepCopy(_spec),
                 searchspace = this.nodes,
                 result;
@@ -551,7 +551,7 @@
             return result;
         },
 
-        findLinksImpl: function (spec, source, target, directed) {
+        findLinksRaw: function (spec, source, target, directed) {
             return _.filter(this.links, function (link) {
                 var directedMatch,
                     sourceMatch = _.isUndefined(source) || (link.source.key === source),

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -568,11 +568,6 @@
 
                 return _.every([sourceMatch, targetMatch, dataMatch, directedMatch]);
             });
-        },
-
-        newNode: _.noop,
-        newLink: _.noop,
-        destroyNode: _.noop,
-        destroyLink: _.noop
+        }
     });
 }(window.clique, window._, window.Backbone, window.jQuery));

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -137,11 +137,7 @@
         };
 
         this.neighborLinkCount = function (node, opts) {
-            if (this.neighborLinkCountImpl) {
-                return this.neighborLinkCountImpl(node, opts);
-            } else {
-                return this.neighborLinks(node, opts).then(_.size);
-            }
+            return this.neighborLinks(node, opts).then(_.size);
         };
 
         this.outgoingLinkCount = function (node) {
@@ -282,13 +278,9 @@
         };
 
         this.neighborCount = function (node, opts) {
-            if (this.neighborCountImpl) {
-                return this.neighborCountImpl(node, opts);
-            } else {
-                return this.neighbors(node, opts).then(function (nbrs) {
-                    return _.size(nbrs.nodes);
-                });
-            }
+            return this.neighbors(node, opts).then(function (nbrs) {
+                return _.size(nbrs.nodes);
+            });
         };
 
         this.outgoingNeighborCount = function (node) {

--- a/tangelo/mongo/web/mongo.js
+++ b/tangelo/mongo/web/mongo.js
@@ -13,7 +13,7 @@
             };
         },
 
-        findNodesImpl: function (spec) {
+        findNodesRaw: function (spec) {
             var data = _.extend({
                 spec: JSON.stringify(spec)
             }, this.mongoStore);
@@ -37,7 +37,7 @@
             });
         },
 
-        findLinksImpl: function (spec, source, target, directed) {
+        findLinksRaw: function (spec, source, target, directed) {
             var data;
 
             data = _.extend({
@@ -66,7 +66,7 @@
             });
         },
 
-        createNodeImpl: function (_data) {
+        createNodeRaw: function (_data) {
             var data;
 
             data  = _.extend({
@@ -98,7 +98,7 @@
             return $.getJSON("plugin/mongo/neighborhood", data);
         },
 
-        createLinkImpl: function (source, target, _data, undirected) {
+        createLinkRaw: function (source, target, _data, undirected) {
             var data;
 
             data = _.extend({
@@ -125,7 +125,7 @@
             });
         },
 
-        destroyNodeImpl: function (key) {
+        destroyNodeRaw: function (key) {
             var data;
 
             data = _.extend({
@@ -135,7 +135,7 @@
             return $.get("plugin/mongo/destroyNode", data);
         },
 
-        destroyLinkImpl: function (key) {
+        destroyLinkRaw: function (key) {
             var data;
 
             data = _.extend({


### PR DESCRIPTION
- Renames functions ending in `Impl` to `Raw` instead
- Removed `Impl` entirely from count functions (since they don't return "raw" results that need further, uniform processing)
