### PR TITLE
Make function names consistent with each other

### DIFF
--- a/data/mongorandomgraph.py
+++ b/data/mongorandomgraph.py
@@ -1,0 +1,47 @@
+import bson.json_util
+from bson.objectid import ObjectId
+import itertools
+import random
+import string
+import sys
+
+
+def emit_node(name):
+    oid = ObjectId()
+
+    print bson.json_util.dumps({"_id": oid,
+                                "type": "node",
+                                "data": {"name": name}})
+
+    return oid
+
+
+def emit_link(oid1, oid2, undirected=False):
+    oid = ObjectId()
+
+    record = {"_id": oid,
+              "type": "link",
+              "source": oid1,
+              "target": oid2,
+              "data": {}}
+
+    if undirected:
+        record["undirected"] = True
+
+    print bson.json_util.dumps(record)
+
+
+def main():
+    table = {letter: emit_node(letter) for letter in string.ascii_lowercase}
+
+    for (a, b) in itertools.product(string.ascii_lowercase, repeat=2):
+        if a == b:
+            continue
+
+        if random.random() > 0.2:
+            undirected = random.random() > 0.5
+
+            emit_link(table[a], table[b], undirected)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -62,12 +62,21 @@
         },
 
         findLinks: function (cfg) {
-            var spec = cfg.spec,
-                source = cfg.source,
-                target = cfg.target,
-                directed = cfg.directed,
-                offset = cfg.offset,
-                limit = cfg.limit;
+            var spec,
+                source,
+                target,
+                directed,
+                offset,
+                limit;
+
+            cfg = cfg || {};
+
+            spec = cfg.spec;
+            source = cfg.source;
+            target = cfg.target;
+            directed = cfg.directed;
+            offset = _.isUndefined(cfg.offset) ? null : cfg.offset;
+            limit = _.isUndefined(cfg.limit) ? null : cfg.limit;
 
             return $.when(this.findLinksRaw(spec, source, target, directed, offset, limit))
                 .then(_.partial(_.map, _, this.addAccessor, this));

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -29,9 +29,15 @@
         initialize: _.noop,
 
         findNodes: function (cfg) {
-            var spec = cfg.spec || {},
-                offset = cfg.offset || 0,
-                limit = cfg.limit;
+            var spec,
+                offset,
+                limit;
+
+            cfg = cfg || {};
+
+            spec = cfg.spec || {};
+            offset = cfg.offset || 0;
+            limit = _.isUndefined(cfg.limit) ? null : cfg.limit;
 
             return $.when(this.findNodesRaw(spec, offset, limit))
                 .then(_.partial(_.map, _, this.addAccessor, this));

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -8,15 +8,13 @@
         this.accessors = {};
         this.onNewAccessor = this.onNewAccessor || _.noop;
         this.addAccessor = function (blob) {
-            var mut,
-                accessors = this.accessors;
+            var accessors = this.accessors,
+                mut = accessors[blob.key];
 
-            if (!_.has(accessors, blob.key)) {
-                accessors[blob.key] = new clique.util.Accessor(blob);
+            if (_.isUndefined(mut)) {
+                mut = accessors[blob.key] = new clique.util.Accessor(blob);
                 this.onNewAccessor(mut);
             }
-
-            mut = accessors[blob.key];
 
             return mut;
         };

--- a/src/js/lib/adapter.js
+++ b/src/js/lib/adapter.js
@@ -238,61 +238,61 @@
             });
         },
 
-        neighborCount: function (node, opts) {
-            return this.neighbors(node, opts).then(function (nbrs) {
+        neighborNodeCount: function (node, opts) {
+            return this.neighborNodes(node, opts).then(function (nbrs) {
                 return _.size(nbrs.nodes);
             });
         },
 
-        outgoingNeighborCount: function (node) {
-            return this.neighborCount(node, {
+        outgoingNodeCount: function (node) {
+            return this.neighborNodeCount(node, {
                 outgoing: true,
                 incoming: false,
                 undirected: false
             });
         },
 
-        outflowingNeighborCount: function (node) {
-            return this.neighborCount(node, {
+        outflowingNodeCount: function (node) {
+            return this.neighborNodeCount(node, {
                 outgoing: true,
                 incoming: false,
                 undirected: true
             });
         },
 
-        incomingNeighborCount: function (node) {
-            return this.neighborCount(node, {
+        incomingNodeCount: function (node) {
+            return this.neighborNodeCount(node, {
                 outgoing: false,
                 incoming: true,
                 undirected: false
             });
         },
 
-        inflowingNeighborCount: function (node) {
-            return this.neighborCount(node, {
+        inflowingNodeCount: function (node) {
+            return this.neighborNodeCount(node, {
                 outgoing: false,
                 incoming: true,
                 undirected: true
             });
         },
 
-        undirectedNeighborCount: function (node) {
-            return this.neighborCount(node, {
+        undirectedNodeCount: function (node) {
+            return this.neighborNodeCount(node, {
                 outgoing: false,
                 incoming: false,
                 undirected: true
             });
         },
 
-        directedNeighborCount: function (node) {
-            return this.neighborCount(node, {
+        directedNodeCount: function (node) {
+            return this.neighborNodeCount(node, {
                 outgoing: true,
                 incoming: true,
                 undirected: false
             });
         },
 
-        neighbors: function (node, opts) {
+        neighborNodes: function (node, opts) {
             var key = node.key(),
                 links;
 
@@ -327,8 +327,8 @@
             });
         },
 
-        outgoingNeighbors: function (node, offset, limit) {
-            return this.neighbors(node, {
+        outgoingNodes: function (node, offset, limit) {
+            return this.neighborNodes(node, {
                 types: {
                     outgoing: true,
                     incoming: false,
@@ -339,8 +339,8 @@
             });
         },
 
-        outflowingNeighbors: function (node, offset, limit) {
-            return this.neighbors(node, {
+        outflowingNodes: function (node, offset, limit) {
+            return this.neighborNodes(node, {
                 types: {
                     outgoing: true,
                     incoming: false,
@@ -351,8 +351,8 @@
             });
         },
 
-        incomingNeighbors: function (node, offset, limit) {
-            return this.neighbors(node, {
+        incomingNodes: function (node, offset, limit) {
+            return this.neighborNodes(node, {
                 types: {
                     outgoing: false,
                     incoming: true,
@@ -363,8 +363,8 @@
             });
         },
 
-        inflowingNeighbors: function (node, offset, limit) {
-            return this.neighbors(node, {
+        inflowingNodes: function (node, offset, limit) {
+            return this.neighborNodes(node, {
                 types: {
                     outgoing: false,
                     incoming: true,
@@ -375,8 +375,8 @@
             });
         },
 
-        undirectedNeighbors: function (node, offset, limit) {
-            return this.neighbors(node, {
+        undirectedNodes: function (node, offset, limit) {
+            return this.neighborNodes(node, {
                 types: {
                     outgoing: false,
                     incoming: false,
@@ -387,8 +387,8 @@
             });
         },
 
-        directedNeighbors: function (node, offset, limit) {
-            return this.neighbors(node, {
+        directedNodes: function (node, offset, limit) {
+            return this.neighborNodes(node, {
                 types: {
                     outgoing: true,
                     incoming: true,

--- a/src/js/lib/model/Graph.js
+++ b/src/js/lib/model/Graph.js
@@ -24,7 +24,7 @@
         },
 
         addNeighborhood: function (node) {
-            return this.adapter.neighbors(node).then(_.bind(function (neighbors) {
+            return this.adapter.neighborNodes(node).then(_.bind(function (neighbors) {
                 _.map(neighbors.nodes, _.partial(this.addNode, _), this);
             }, this));
         },

--- a/tangelo/mongo/web/findLinks.py
+++ b/tangelo/mongo/web/findLinks.py
@@ -8,11 +8,15 @@ def load_json(value, default):
     return default if value is None else json.loads(value)
 
 
-def run(host=None, db=None, coll=None, spec=None, source=None, target=None, directed=None):
+def run(host=None, db=None, coll=None, spec=None, source=None, target=None, directed=None, offset=None, limit=None):
     # Connect to the mongo collection.
     client = MongoClient(host)
     db = client[db]
     graph = db[coll]
+
+    # Parse the offset and limit arguments.
+    offset = 0 if offset is None else int(offset)
+    limit = 0 if limit is None else int(limit)
 
     spec = load_json(spec, {})
     directed = load_json(directed, None)
@@ -49,4 +53,4 @@ def run(host=None, db=None, coll=None, spec=None, source=None, target=None, dire
     query = {"$and": [matcher, directedness]}
 
     # Perform the query and return the result(s).
-    return bson.json_util.dumps(list(graph.find(query)))
+    return bson.json_util.dumps(list(graph.find(query, skip=offset, limit=limit)))

--- a/tangelo/mongo/web/findNodes.py
+++ b/tangelo/mongo/web/findNodes.py
@@ -4,11 +4,15 @@ import json
 from pymongo import MongoClient
 
 
-def run(host=None, db=None, coll=None, spec=None):
+def run(host=None, db=None, coll=None, spec=None, offset=None, limit=None):
     # Connect to the mongo collection.
     client = MongoClient(host)
     db = client[db]
     graph = db[coll]
+
+    # Parse the offset and limit arguments.
+    offset = 0 if offset is None else int(offset)
+    limit = 0 if limit is None else int(limit)
 
     spec = json.loads(spec)
     spec2 = {"type": "node"}
@@ -18,6 +22,6 @@ def run(host=None, db=None, coll=None, spec=None):
         else:
             spec2["data.%s" % (k)] = v
 
-    result = list(graph.find(spec2))
+    result = list(graph.find(spec2, skip=offset, limit=limit))
 
     return bson.json_util.dumps(result)

--- a/tangelo/mongo/web/mongo.js
+++ b/tangelo/mongo/web/mongo.js
@@ -94,16 +94,6 @@
             });
         },
 
-        neighborhood: function (node, radius, linklimit) {
-            var data = _.extend({
-                start_key: node.key(),
-                radius: radius,
-                linklimit: linklimit
-            }, this.mongoStore);
-
-            return $.getJSON("plugin/mongo/neighborhood", data);
-        },
-
         createLinkRaw: function (source, target, _data, undirected) {
             var data;
 
@@ -149,6 +139,16 @@
             }, this.mongoStore);
 
             return $.get("plugin/mongo/destroyLink", data);
-        }
+        },
+
+        neighborhood: function (node, radius, linklimit) {
+            var data = _.extend({
+                start_key: node.key(),
+                radius: radius,
+                linklimit: linklimit
+            }, this.mongoStore);
+
+            return $.getJSON("plugin/mongo/neighborhood", data);
+        },
     });
 }(window.clique, window.jQuery, window._, window.Backbone, window.tangelo));

--- a/tangelo/mongo/web/mongo.js
+++ b/tangelo/mongo/web/mongo.js
@@ -48,7 +48,7 @@
                 spec: JSON.stringify(spec || {}),
                 source: source,
                 target: target,
-                directed: JSON.stringify(_.isUndefined(directed) ? null : cfg.directed),
+                directed: JSON.stringify(_.isUndefined(directed) ? null : directed),
                 offset: offset || 0,
                 limit: limit || 0
             }, this.mongoStore);
@@ -70,6 +70,20 @@
                     return result;
                 });
             });
+        },
+
+        neighborLinkCount: function (node, opts) {
+            var data;
+
+            opts = opts || {};
+            data = _.extend({
+                node: node.key(),
+                outgoing: _.isUndefined(opts.outgoing) ? true : opts.outgoing,
+                incoming: _.isUndefined(opts.incoming) ? true : opts.incoming,
+                undirected: _.isUndefined(opts.undirected) ? true : opts.undirected
+            }, this.mongoStore);
+
+            return $.getJSON("plugin/mongo/neighborLinkCount", data);
         },
 
         createNodeRaw: function (_data) {

--- a/tangelo/mongo/web/mongo.js
+++ b/tangelo/mongo/web/mongo.js
@@ -13,13 +13,13 @@
             };
         },
 
-        findNodesRaw: function (cfg) {
+        findNodesRaw: function (spec, offset, limit) {
             var data;
 
             data = _.extend({
-                spec: JSON.stringify(cfg.spec || {}),
-                offset: _.isUndefined(cfg.offset) ? null : cfg.offset,
-                limit: _.isUndefined(cfg.limit) ? null : cfg.limit,
+                spec: JSON.stringify(spec || {}),
+                offset: offset || 0,
+                limit: limit || 0,
             }, this.mongoStore);
 
             return $.getJSON("plugin/mongo/findNodes", data).then(function (responses) {

--- a/tangelo/mongo/web/mongo.js
+++ b/tangelo/mongo/web/mongo.js
@@ -86,6 +86,20 @@
             return $.getJSON("plugin/mongo/neighborLinkCount", data);
         },
 
+        neighborCount: function (node, opts) {
+            var data;
+
+            opts = opts || {};
+            data = _.extend({
+                node: node.key(),
+                outgoing: _.isUndefined(opts.outgoing) ? true : opts.outgoing,
+                incoming: _.isUndefined(opts.incoming) ? true : opts.incoming,
+                undirected: _.isUndefined(opts.undirected) ? true : opts.undirected
+            }, this.mongoStore);
+
+            return $.getJSON("plugin/mongo/neighborCount", data);
+        },
+
         createNodeRaw: function (_data) {
             var data;
 

--- a/tangelo/mongo/web/mongo.js
+++ b/tangelo/mongo/web/mongo.js
@@ -41,16 +41,16 @@
             });
         },
 
-        findLinksRaw: function (cfg) {
+        findLinksRaw: function (spec, source, target, directed, offset, limit) {
             var data;
 
             data = _.extend({
-                spec: JSON.stringify(cfg.spec || {}),
-                source: cfg.source,
-                target: cfg.target,
-                directed: JSON.stringify(_.isUndefined(cfg.directed) ? null : cfg.directed),
-                offset: _.isUndefined(cfg.offset) ? null : cfg.offset,
-                limit: _.isUndefined(cfg.offset) ? null : cfg.offset
+                spec: JSON.stringify(spec || {}),
+                source: source,
+                target: target,
+                directed: JSON.stringify(_.isUndefined(directed) ? null : cfg.directed),
+                offset: offset || 0,
+                limit: limit || 0
             }, this.mongoStore);
 
             return $.getJSON("plugin/mongo/findLinks", data).then(function (responses) {

--- a/tangelo/mongo/web/mongo.js
+++ b/tangelo/mongo/web/mongo.js
@@ -13,9 +13,13 @@
             };
         },
 
-        findNodesRaw: function (spec) {
-            var data = _.extend({
-                spec: JSON.stringify(spec)
+        findNodesRaw: function (cfg) {
+            var data;
+
+            data = _.extend({
+                spec: JSON.stringify(cfg.spec || {}),
+                offset: _.isUndefined(cfg.offset) ? null : cfg.offset,
+                limit: _.isUndefined(cfg.limit) ? null : cfg.limit,
             }, this.mongoStore);
 
             return $.getJSON("plugin/mongo/findNodes", data).then(function (responses) {
@@ -37,14 +41,16 @@
             });
         },
 
-        findLinksRaw: function (spec, source, target, directed) {
+        findLinksRaw: function (cfg) {
             var data;
 
             data = _.extend({
-                spec: JSON.stringify(spec),
-                source: source,
-                target: target,
-                directed: JSON.stringify(_.isUndefined(directed) ? null : directed)
+                spec: JSON.stringify(cfg.spec || {}),
+                source: cfg.source,
+                target: cfg.target,
+                directed: JSON.stringify(_.isUndefined(cfg.directed) ? null : cfg.directed),
+                offset: _.isUndefined(cfg.offset) ? null : cfg.offset,
+                limit: _.isUndefined(cfg.offset) ? null : cfg.offset
             }, this.mongoStore);
 
             return $.getJSON("plugin/mongo/findLinks", data).then(function (responses) {

--- a/tangelo/mongo/web/neighborCount.py
+++ b/tangelo/mongo/web/neighborCount.py
@@ -1,0 +1,49 @@
+from bson.objectid import ObjectId
+import json
+from pymongo import MongoClient
+
+
+def run(host=None, db=None, coll=None, node=None, outgoing="true", incoming="true", undirected="true"):
+    # Connect to the mongo collection.
+    graph = MongoClient(host)[db][coll]
+
+    outgoing = json.loads(outgoing)
+    incoming = json.loads(incoming)
+    undirected = json.loads(undirected)
+
+    # Construct the query according to the given options.
+    query = {"type": "link"}
+    clauses = []
+    oid = ObjectId(node)
+    if outgoing or incoming:
+        dirclauses = []
+        orclause = {"$or": [{"undirected": {"$not": {"$exists": 1}}},
+                            {"undirected": False}]}
+        if outgoing:
+            dirclauses.append({"source": oid})
+
+        if incoming:
+            dirclauses.append({"target": oid})
+
+        clauses.append({"$and": [orclause, {"$or": dirclauses}]})
+
+    if undirected:
+        clauses.append({"$and": [{"undirected": True},
+                                 {"$or": [{"source": oid},
+                                          {"target": oid}]}]})
+
+    query["$or"] = clauses
+
+    # Get all the links
+    links = graph.find(query)
+
+    # Count the unique nodes adjacent to the target node.
+    seen = set()
+    for link in links:
+        source = str(link["source"])
+        target = str(link["target"])
+
+        nbr = source if node == target else target
+        seen.add(nbr)
+
+    return json.dumps(len(seen))

--- a/tangelo/mongo/web/neighborLinkCount.py
+++ b/tangelo/mongo/web/neighborLinkCount.py
@@ -1,0 +1,37 @@
+from bson.objectid import ObjectId
+import json
+from pymongo import MongoClient
+
+
+def run(host=None, db=None, coll=None, node=None, outgoing="true", incoming="true", undirected="true"):
+    # Connect to the mongo collection.
+    graph = MongoClient(host)[db][coll]
+
+    outgoing = json.loads(outgoing)
+    incoming = json.loads(incoming)
+    undirected = json.loads(undirected)
+
+    # Construct the query according to the given options.
+    query = {"type": "link"}
+    clauses = []
+    oid = ObjectId(node)
+    if outgoing or incoming:
+        dirclauses = []
+        orclause = {"$or": [{"undirected": {"$not": {"$exists": 1}}},
+                            {"undirected": False}]}
+        if outgoing:
+            dirclauses.append({"source": oid})
+
+        if incoming:
+            dirclauses.append({"target": oid})
+
+        clauses.append({"$and": [orclause, {"$or": dirclauses}]})
+
+    if undirected:
+        clauses.append({"$and": [{"undirected": True},
+                                 {"$or": [{"source": oid},
+                                          {"target": oid}]}]})
+
+    query["$or"] = clauses
+
+    return json.dumps(graph.count(query))

--- a/tangelo/mongo/web/neighborLinks.py
+++ b/tangelo/mongo/web/neighborLinks.py
@@ -1,0 +1,41 @@
+from bson.objectid import ObjectId
+import bson.json_util
+import json
+from pymongo import MongoClient
+
+
+def run(host=None, db=None, coll=None, node=None, outgoing="true", incoming="true", undirected="true", offset=0, limit=0):
+    # Connect to the mongo collection.
+    graph = MongoClient(host)[db][coll]
+
+    outgoing = json.loads(outgoing)
+    incoming = json.loads(incoming)
+    undirected = json.loads(undirected)
+
+    offset = int(offset)
+    limit = int(limit)
+
+    # Construct the query according to the given options.
+    query = {"type": "link"}
+    clauses = []
+    oid = ObjectId(node)
+    if outgoing or incoming:
+        dirclauses = []
+        orclause = {"$or": [{"undirected": {"$not": {"$exists": 1}}},
+                            {"undirected": False}]}
+        if outgoing:
+            dirclauses.append({"source": oid})
+
+        if incoming:
+            dirclauses.append({"target": oid})
+
+        clauses.append({"$and": [orclause, {"$or": dirclauses}]})
+
+    if undirected:
+        clauses.append({"$and": [{"undirected": True},
+                                 {"$or": [{"source": oid},
+                                          {"target": oid}]}]})
+
+    query["$or"] = clauses
+
+    return bson.json_util.dumps(list(graph.find(query, skip=offset, limit=limit)))


### PR DESCRIPTION
The functions for getting neighboring links and nodes now have a consistent naming scheme:
- The base function is `neighborThings()` with `Thing` is either `Node` or `Link`
- The specialized functions that treat specific types of links are now named `outgoingThings()`, `incomingThings()`, `outflowingThings()`, `inflowingThings()`, `directedThings()`, and `undirectedThings()`.
- The function that counts the number of nodes/links is `neighborThingCount()`. The specialized versions are `outgoingThingCount()` etc. (as above).
