### PR TITLE
Allow for "in-source" tests

### DIFF
--- a/src/clique/test/clique-exports.js
+++ b/src/clique/test/clique-exports.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 
-import clique from './../src/clique';
+import clique from '..';
 
 test('Check for all parts of ES5-compatible clique object', t => {
   t.ok(clique, 'clique exists');

--- a/tests.bundle.js
+++ b/tests.bundle.js
@@ -1,5 +1,2 @@
-var context = require.context('./test', true, /\.js$/);
-context.keys().forEach(context);
-
-context = require.context('./src/clique', true, /\.js$/);
+var context = require.context('./src/clique', true, /\.js$/);
 context.keys().forEach(context);


### PR DESCRIPTION
Put tests in "test" subdirectories anywhere within the "clique" directory. They
will be run as before, with coverage, but this makes it easier to move chunks of
code around, etc.
