### PR TITLE
Speed up deselection of nodes and links.

### DIFF
--- a/src/clique/view.js
+++ b/src/clique/view.js
@@ -775,15 +775,19 @@ const Cola = Backbone.View.extend({
         // If shift is not held at the beginning of the operation,
         // then remove the current selections.
         if (!d3.event.shiftKey) {
-          _.each(that.model.get('nodes'), _.bind(function (node) {
-            that.selection.remove(node.key);
-          }, this));
+          var rerender;
+          _.each(that.selection.items(), function (key) {
+            that.selection.remove(key);
+            rerender = true;
+          });
 
-          that.renderNodes(that.nodes);
+          if (rerender) {
+            that.renderNodes(that.nodes);
+          }
 
-          _.each(that.model.get('links'), _.bind(function (link) {
-            that.linkSelection.remove(link.key);
-          }, this));
+          _.each(that.linkSelection.items(), function (key) {
+            that.linkSelection.remove(key);
+          });
         }
 
         origin = that.$el.offset();


### PR DESCRIPTION
Whenever a mouse down event occured, all links and all nodes, regardless of state, were explicitly deselected.  For each node and link, and event was triggered that it had been removed from the selection.  For even modest sized graphs of a few hundred nodes, this results in a very slow process.  Clicking in a black space on the graph multiple times would bind up the web page in copious callbacks (which would also trigger many GC cycles).

This has been changed to only deselect selected nodes and links, and only to rerender nodes if a node was deselected.  remove events are only fired for nodes and links that were actually deselected.
